### PR TITLE
Change readme.md to suggest install from GitHub link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,14 +18,12 @@ This requires [Rust](https://www.rust-lang.org/tools/install) to be installed.
 
 You can install with:
 ```
-git clone https://github.com/uiua-lang/uiua
-cd uiua
-cargo install --path .
+cargo install --git https://github.com/uiua-lang/uiua uiua
 ```
 
 To enable audio output, replace the cargo command with:
 ```
-cargo install --path . --features audio
+cargo install --git https://github.com/uiua-lang/uiua uiua --features audio
 ```
 
 If you want audio on Linux, you may need to install some dependencies first:


### PR DESCRIPTION
`cargo` allows installing binaries directly from a git repository.
This provides a better user experience as it allows them to run one command to install the binary and not having to worry about deleting the repo afterwards.
