### PR TITLE
Update viuer to a version that supports kitty 0.26.0+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3345,8 +3345,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "viuer"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b511f7e9ae27b5750f12ca50c353a1179bd4cc964a47294eb0d2cdad40cb41c0"
+source = "git+https://github.com/atanunq/viuer?rev=refs/pull/51/head#dda458ef1c5c78d1de2e6c290a8387c9598a9691"
 dependencies = [
  "ansi_colours",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3207,12 +3207,16 @@ dependencies = [
 name = "uiua"
 version = "0.0.14"
 dependencies = [
+ "ansi_colours",
  "ariadne",
+ "base64 0.13.1",
  "bufreaderwriter",
  "clap",
  "color-backtrace",
  "colored",
+ "console",
  "crossbeam-channel",
+ "crossterm",
  "ctrlc",
  "dashmap",
  "ecow",
@@ -3223,6 +3227,7 @@ dependencies = [
  "image",
  "indexmap 1.9.3",
  "instant",
+ "lazy_static",
  "lockfree",
  "notify",
  "once_cell",
@@ -3232,11 +3237,12 @@ dependencies = [
  "rustls",
  "serde",
  "serde_yaml",
+ "tempfile",
  "term_size",
+ "termcolor",
  "tinyvec",
  "tokio",
  "tower-lsp",
- "viuer",
  "webpki-roots",
 ]
 
@@ -3341,21 +3347,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "viuer"
-version = "0.6.2"
-source = "git+https://github.com/atanunq/viuer?rev=refs/pull/51/head#dda458ef1c5c78d1de2e6c290a8387c9598a9691"
-dependencies = [
- "ansi_colours",
- "base64 0.13.1",
- "console",
- "crossterm",
- "image",
- "lazy_static",
- "tempfile",
- "termcolor",
-]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,12 +217,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
@@ -696,11 +690,11 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -1622,7 +1616,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ec5366c79892fa8232dcfa6f05d610d0fd780af155fea8c466e77da18e744f"
 dependencies = [
- "base64 0.21.4",
+ "base64",
  "cfg-if",
  "futures",
  "indexmap 2.0.2",
@@ -2152,7 +2146,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdc0001cfea3db57a2e24bc0d818e9e20e554b5f97fabb9bc231dc240269ae06"
 dependencies = [
- "base64 0.21.4",
+ "base64",
  "indexmap 1.9.3",
  "line-wrap",
  "quick-xml",
@@ -2385,7 +2379,7 @@ version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
- "base64 0.21.4",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2740,7 +2734,7 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 name = "site"
 version = "0.1.0"
 dependencies = [
- "base64 0.21.4",
+ "base64",
  "comrak",
  "console_error_panic_hook",
  "enum-iterator",
@@ -3209,7 +3203,7 @@ version = "0.0.14"
 dependencies = [
  "ansi_colours",
  "ariadne",
- "base64 0.13.1",
+ "base64",
  "bufreaderwriter",
  "clap",
  "color-backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,13 +66,24 @@ tokio.optional = true
 tokio.version = "1"
 tower-lsp.optional = true
 tower-lsp.version = "0.19.0"
-# TODO: revert back to a main release of viuer if a new version gets cut.
-viuer.optional = true
-viuer.version = "0.6.2"
-viuer.git = "https://github.com/atanunq/viuer"
-viuer.rev = "refs/pull/51/head"
 webpki-roots.optional = true
 webpki-roots.version = "0.25.0"
+# Dependencies from viuer
+termcolor.version = "1.1"
+termcolor.optional = true
+crossterm.version = "0.25"
+crossterm.optional = true
+ansi_colours.version = "1.0"
+ansi_colours.optional = true
+base64.version = "0.13"
+base64.optional = true
+tempfile.version = "3.1"
+tempfile.optional = true
+console.version = "0.15"
+console.default-features = false
+console.optional = true
+lazy_static.version = "1.4"
+lazy_static.optional = true
 
 [features]
 audio = ["hodaun", "crossbeam-channel", "lockfree"]
@@ -82,7 +93,7 @@ default = ["binary", "terminal_image", "https"]
 https = ["httparse", "rustls", "webpki-roots"]
 lsp = ["tower-lsp", "tokio"]
 profile = ["crossbeam-channel", "serde", "serde_yaml", "indexmap"]
-terminal_image = ["viuer"]
+terminal_image = ["termcolor", "crossterm", "ansi_colours", "base64", "tempfile", "console", "lazy_static"]
 
 [[bin]]
 name = "uiua"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,11 +71,11 @@ webpki-roots.version = "0.25.0"
 # Dependencies from viuer
 termcolor.version = "1.1"
 termcolor.optional = true
-crossterm.version = "0.25"
+crossterm.version = "0.27"
 crossterm.optional = true
 ansi_colours.version = "1.0"
 ansi_colours.optional = true
-base64.version = "0.13"
+base64.version = "0.21"
 base64.optional = true
 tempfile.version = "3.1"
 tempfile.optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,11 @@ tokio.optional = true
 tokio.version = "1"
 tower-lsp.optional = true
 tower-lsp.version = "0.19.0"
+# TODO: revert back to a main release of viuer if a new version gets cut.
 viuer.optional = true
 viuer.version = "0.6.2"
+viuer.git = "https://github.com/atanunq/viuer"
+viuer.rev = "refs/pull/51/head"
 webpki-roots.optional = true
 webpki-roots.version = "0.25.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ pub mod profile;
 pub mod run;
 mod sys;
 pub mod value;
+#[cfg(feature = "terminal_image")]
+mod viuer;
 
 use std::sync::Arc;
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -682,9 +682,9 @@ impl SysBackend for NativeSys {
         } else {
             (None, None)
         };
-        viuer::print(
+        crate::viuer::print(
             &image,
-            &viuer::Config {
+            &crate::viuer::Config {
                 width,
                 height,
                 absolute_offset: false,

--- a/src/viuer/LICENSE-MIT
+++ b/src/viuer/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Atanas Yankov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/viuer/README.md
+++ b/src/viuer/README.md
@@ -1,0 +1,63 @@
+# viuer
+
+| :exclamation:  Warning, viuer is just copied from [atanunq/viuer](https://github.com/atanunq/viuer) because it does not seem to be maintained anymore|
+|---|
+
+Display images in the terminal with ease.
+
+![ci](https://github.com/atanunq/viuer/workflows/ci/badge.svg)
+
+`viuer` is a Rust library that makes it easy to show images in the
+terminal. It has a straightforward interface and is configured
+through a single struct. The default printing method is through
+lower half blocks (▄ or \u2585). However some custom graphics
+protocols are supported. They result in full resolution images
+being displayed in specific environments:
+
+- [Kitty](https://sw.kovidgoyal.net/kitty/graphics-protocol.html)
+- [iTerm](https://iterm2.com/documentation-images.html)
+- [Sixel](https://github.com/saitoha/libsixel) (behind the "sixel" feature gate)
+
+## Usage
+Add this to `Cargo.toml`:
+```toml
+[dependencies]
+viuer = "0.6"
+```
+
+For a demo of the library's usage and example screenshots, see [`viu`](https://github.com/atanunq/viu).
+
+## Examples
+
+```rust
+// src/main.rs
+use viuer::{print_from_file, Config};
+
+fn main() {
+    let conf = Config {
+        // set offset
+        x: 20,
+        y: 4,
+        // set dimensions
+        width: Some(80),
+        height: Some(25),
+        ..Default::default()
+    };
+
+    // starting from row 4 and column 20,
+    // display `img.jpg` with dimensions 80x25 (in terminal cells)
+    // note that the actual resolution in the terminal will be 80x50
+    print_from_file("img.jpg", &conf).expect("Image printing failed.");
+}
+```
+
+Or if you have a [DynamicImage](https://docs.rs/image/*/image/enum.DynamicImage.html), you can use it directly:
+```rust
+// ..Config setup
+
+let img = image::DynamicImage::ImageRgba8(image::RgbaImage::new(20, 10));
+viuer::print(&img, &conf).expect("Image printing failed.");
+```
+
+## Docs
+Check the [full documentation](https://docs.rs/crate/viuer) for examples and all the configuration options.

--- a/src/viuer/config.rs
+++ b/src/viuer/config.rs
@@ -1,0 +1,51 @@
+use crate::viuer::utils;
+
+/// Configuration struct to customize printing behaviour.
+pub struct Config {
+    /// Enable true transparency instead of checkerboard background.
+    /// Available only for the block printer. Defaults to false.
+    pub transparent: bool,
+    /// Make the x and y offset be relative to the top left terminal corner.
+    /// If false, the y offset is relative to the cursor's position.
+    /// Defaults to true.
+    pub absolute_offset: bool,
+    /// X offset. Defaults to 0.
+    pub x: u16,
+    /// Y offset. Can be negative only when `absolute_offset` is `false`. Defaults to 0.
+    pub y: i16,
+    /// Take a note of cursor position before printing and restore it when finished.
+    /// Defaults to false.
+    pub restore_cursor: bool,
+    /// Optional image width. Defaults to None.
+    pub width: Option<u32>,
+    /// Optional image height. Defaults to None.
+    pub height: Option<u32>,
+    /// Use truecolor if the terminal supports it. Defaults to true.
+    pub truecolor: bool,
+    /// Use Kitty protocol if the terminal supports it. Defaults to true.
+    pub use_kitty: bool,
+    /// Use iTerm protocol if the terminal supports it. Defaults to true.
+    pub use_iterm: bool,
+    /// Use Sixel protocol if the terminal supports it. Defaults to true.
+    #[cfg(feature = "sixel")]
+    pub use_sixel: bool,
+}
+
+impl std::default::Default for Config {
+    fn default() -> Self {
+        Self {
+            transparent: false,
+            absolute_offset: true,
+            x: 0,
+            y: 0,
+            restore_cursor: false,
+            width: None,
+            height: None,
+            truecolor: utils::truecolor_available(),
+            use_kitty: true,
+            use_iterm: true,
+            #[cfg(feature = "sixel")]
+            use_sixel: true,
+        }
+    }
+}

--- a/src/viuer/error.rs
+++ b/src/viuer/error.rs
@@ -1,0 +1,63 @@
+/// Custom result type for error-prone operations
+pub type ViuResult<T = ()> = std::result::Result<T, ViuError>;
+
+/// Custom error enum for `viu`ing operations
+#[derive(Debug)]
+pub enum ViuError {
+    /// Error while doing transformations with the [`image`] crate
+    Image(image::ImageError),
+    /// Error while doing IO operations
+    Io(std::io::Error),
+    /// Invalid configuration provided
+    InvalidConfiguration(String),
+    /// Error while creating temp files
+    Tempfile(tempfile::PersistError),
+    /// Errenous response received from Kitty
+    KittyResponse(Vec<console::Key>),
+    /// Kitty protocol not supported
+    KittyNotSupported,
+    /// Error while printing with sixel
+    #[cfg(feature = "sixel")]
+    SixelError(sixel_rs::status::Error),
+}
+
+impl std::error::Error for ViuError {}
+
+impl From<std::io::Error> for ViuError {
+    fn from(err: std::io::Error) -> Self {
+        ViuError::Io(err)
+    }
+}
+impl From<image::ImageError> for ViuError {
+    fn from(err: image::ImageError) -> Self {
+        ViuError::Image(err)
+    }
+}
+
+impl From<tempfile::PersistError> for ViuError {
+    fn from(err: tempfile::PersistError) -> Self {
+        ViuError::Tempfile(err)
+    }
+}
+
+#[cfg(feature = "sixel")]
+impl From<sixel_rs::status::Error> for ViuError {
+    fn from(e: sixel_rs::status::Error) -> Self {
+        ViuError::SixelError(e)
+    }
+}
+
+impl std::fmt::Display for ViuError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ViuError::Image(e) => write!(f, "Image error: {}", e),
+            ViuError::Io(e) => write!(f, "IO error: {}", e),
+            ViuError::InvalidConfiguration(s) => write!(f, "Invalid Configuration: {}", s),
+            ViuError::Tempfile(e) => write!(f, "Tempfile error: {}", e),
+            ViuError::KittyResponse(keys) => write!(f, "Kitty response: {:?}", keys),
+            ViuError::KittyNotSupported => write!(f, "Kitty graphics protocol not supported"),
+            #[cfg(feature = "sixel")]
+            ViuError::SixelError(e) => write!(f, "Sixel error: {:?}", e),
+        }
+    }
+}

--- a/src/viuer/mod.rs
+++ b/src/viuer/mod.rs
@@ -14,7 +14,7 @@
 //! The example below shows how to print the image `img.jpg` in 40x30 terminal cells, with vertical
 //! offset of 4 and horizontal of 10, starting from the top left corner. More options are available
 //! through the [Config] struct.
-//! ```no_run
+//! ```ignore
 //! use viuer::{Config, print_from_file};
 //! let conf = Config {
 //!     width: Some(40),
@@ -57,7 +57,7 @@ pub use printer::is_sixel_supported;
 /// The snippet below reads all of stdin, decodes it with the [`image`] crate
 /// and prints it to the terminal. The image will also be resized to fit in the terminal.
 ///
-/// ```no_run
+/// ```ignore
 /// use std::io::{stdin, Read};
 /// use viuer::{Config, print};
 ///
@@ -90,7 +90,7 @@ pub fn print(img: &DynamicImage, config: &Config) -> ViuResult<(u32, u32)> {
 /// Helper method that reads a file, tries to decode it and prints it.
 ///
 /// ## Example
-/// ```no_run
+/// ```ignore
 /// use viuer::{Config, print_from_file};
 /// let conf = Config {
 ///     width: Some(30),

--- a/src/viuer/mod.rs
+++ b/src/viuer/mod.rs
@@ -1,0 +1,133 @@
+#![deny(missing_docs)]
+#![allow(dead_code)]
+
+//! Library to display images in the terminal.
+//!
+//! This library contains functionality extracted from the [`viu`](https://github.com/atanunq/viu) crate.
+//! It aims to provide an easy to use interface to print images in the terminal. Uses some abstractions
+//! provided by the [`image`] crate. Both the [Kitty](https://sw.kovidgoyal.net/kitty/graphics-protocol.html)
+//! and [iTerm](https://iterm2.com/documentation-images.html) graphic protocols are supported.
+//! By default, they are used if detected. If not, `viuer` will fallback to using regular
+//! half blocks instead (▄ and ▀).
+//!
+//! ## Basic Usage
+//! The example below shows how to print the image `img.jpg` in 40x30 terminal cells, with vertical
+//! offset of 4 and horizontal of 10, starting from the top left corner. More options are available
+//! through the [Config] struct.
+//! ```no_run
+//! use viuer::{Config, print_from_file};
+//! let conf = Config {
+//!     width: Some(40),
+//!     height: Some(30),
+//!     x: 10,
+//!     y: 4,
+//!     ..Default::default()
+//! };
+//! // will resize the image to fit in 40x30 terminal cells and print it
+//! print_from_file("img.jpg", &conf).expect("Image printing failed.");
+//! ```
+
+use std::path::Path;
+
+use crossterm::{
+    cursor::{RestorePosition, SavePosition},
+    execute,
+};
+use image::DynamicImage;
+use printer::{Printer, PrinterType};
+
+mod config;
+mod error;
+mod printer;
+mod utils;
+
+pub use config::Config;
+pub use error::{ViuError, ViuResult};
+pub use printer::{get_kitty_support, is_iterm_supported, resize, KittySupport};
+pub use utils::terminal_size;
+
+#[cfg(feature = "sixel")]
+pub use printer::is_sixel_supported;
+
+/// Default printing method. Uses either iTerm or Kitty graphics protocol, if supported,
+/// and half blocks otherwise.
+///
+/// Check the [Config] struct for all customization options.
+/// ## Example
+/// The snippet below reads all of stdin, decodes it with the [`image`] crate
+/// and prints it to the terminal. The image will also be resized to fit in the terminal.
+///
+/// ```no_run
+/// use std::io::{stdin, Read};
+/// use viuer::{Config, print};
+///
+/// let stdin = stdin();
+/// let mut handle = stdin.lock();
+///
+/// let mut buf: Vec<u8> = Vec::new();
+/// let _ = handle
+///     .read_to_end(&mut buf)
+///     .expect("Could not read until EOF.");
+///
+/// let img = image::load_from_memory(&buf).expect("Data from stdin could not be decoded.");
+/// print(&img, &Config::default()).expect("Image printing failed.");
+/// ```
+pub fn print(img: &DynamicImage, config: &Config) -> ViuResult<(u32, u32)> {
+    let mut stdout = std::io::stdout();
+    if config.restore_cursor {
+        execute!(&mut stdout, SavePosition)?;
+    }
+
+    let (w, h) = choose_printer(config).print(&mut stdout, img, config)?;
+
+    if config.restore_cursor {
+        execute!(&mut stdout, RestorePosition)?;
+    };
+
+    Ok((w, h))
+}
+
+/// Helper method that reads a file, tries to decode it and prints it.
+///
+/// ## Example
+/// ```no_run
+/// use viuer::{Config, print_from_file};
+/// let conf = Config {
+///     width: Some(30),
+///     transparent: true,
+///     ..Default::default()
+/// };
+/// // Image will be scaled down to width 30. Aspect ratio will be preserved.
+/// // Also, the terminal's background color will be used instead of checkerboard pattern.
+/// print_from_file("img.jpg", &conf).expect("Image printing failed.");
+/// ```
+pub fn print_from_file<P: AsRef<Path>>(filename: P, config: &Config) -> ViuResult<(u32, u32)> {
+    let mut stdout = std::io::stdout();
+    if config.restore_cursor {
+        execute!(&mut stdout, SavePosition)?;
+    }
+
+    let (w, h) = choose_printer(config).print_from_file(&mut stdout, filename, config)?;
+
+    if config.restore_cursor {
+        execute!(&mut stdout, RestorePosition)?;
+    };
+
+    Ok((w, h))
+}
+
+// Choose the appropriate printer to use based on user config and availability
+fn choose_printer(config: &Config) -> PrinterType {
+    #[cfg(feature = "sixel")]
+    if config.use_sixel && is_sixel_supported() {
+        return PrinterType::Sixel;
+    }
+
+    if config.use_iterm && is_iterm_supported() {
+        PrinterType::iTerm
+    } else if config.use_kitty && get_kitty_support() != KittySupport::None {
+        PrinterType::Kitty
+    } else {
+        PrinterType::Block
+    }
+}

--- a/src/viuer/printer/block.rs
+++ b/src/viuer/printer/block.rs
@@ -1,0 +1,326 @@
+use crate::viuer::error::ViuResult;
+use crate::viuer::printer::{adjust_offset, Printer};
+use crate::viuer::Config;
+
+use ansi_colours::ansi256_from_rgb;
+use image::{DynamicImage, GenericImageView, Rgba};
+use std::io::Write;
+use termcolor::{BufferedStandardStream, Color, ColorChoice, ColorSpec, WriteColor};
+
+use crossterm::cursor::MoveRight;
+use crossterm::execute;
+
+const UPPER_HALF_BLOCK: &str = "\u{2580}";
+const LOWER_HALF_BLOCK: &str = "\u{2584}";
+
+const CHECKERBOARD_BACKGROUND_LIGHT: (u8, u8, u8) = (153, 153, 153);
+const CHECKERBOARD_BACKGROUND_DARK: (u8, u8, u8) = (102, 102, 102);
+
+pub struct BlockPrinter;
+
+impl Printer for BlockPrinter {
+    fn print(
+        &self,
+        // TODO: The provided object is not used because termcolor needs an implementation of the WriteColor trait
+        _stdout: &mut impl Write,
+        img: &DynamicImage,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
+        let mut stream = BufferedStandardStream::stdout(ColorChoice::Always);
+        print_to_writecolor(&mut stream, img, config)
+    }
+}
+
+fn print_to_writecolor(
+    stdout: &mut impl WriteColor,
+    img: &DynamicImage,
+    config: &Config,
+) -> ViuResult<(u32, u32)> {
+    // adjust with x=0 and handle horizontal offset entirely below
+    adjust_offset(stdout, &Config { x: 0, ..*config })?;
+
+    // resize the image so that it fits in the constraints, if any
+    let img = super::resize(img, config.width, config.height);
+    let (width, height) = img.dimensions();
+
+    let mut row_color_buffer: Vec<ColorSpec> = vec![ColorSpec::new(); width as usize];
+    let img_buffer = img.to_rgba8(); //TODO: Can conversion be avoided?
+
+    for (curr_row, img_row) in img_buffer.enumerate_rows() {
+        let is_even_row = curr_row % 2 == 0;
+        let is_last_row = curr_row == height - 1;
+
+        // move right if x offset is specified
+        if config.x > 0 && (!is_even_row || is_last_row) {
+            execute!(stdout, MoveRight(config.x))?;
+        }
+
+        for pixel in img_row {
+            // choose the half block's color
+            let color = if is_pixel_transparent(pixel) {
+                if config.transparent {
+                    None
+                } else {
+                    Some(get_transparency_color(curr_row, pixel.0, config.truecolor))
+                }
+            } else {
+                Some(get_color_from_pixel(pixel, config.truecolor))
+            };
+
+            // Even rows modify the background, odd rows the foreground
+            // because lower half blocks are used by default
+            let colorspec = &mut row_color_buffer[pixel.0 as usize];
+            if is_even_row {
+                colorspec.set_bg(color);
+                if is_last_row {
+                    write_colored_character(stdout, colorspec, true)?;
+                }
+            } else {
+                colorspec.set_fg(color);
+                write_colored_character(stdout, colorspec, false)?;
+            }
+        }
+
+        if !is_even_row && !is_last_row {
+            stdout.reset()?;
+            writeln!(stdout, "\r")?;
+        }
+    }
+
+    stdout.reset()?;
+    writeln!(stdout)?;
+    stdout.flush()?;
+
+    Ok((width, height / 2 + height % 2))
+}
+
+fn write_colored_character(
+    stdout: &mut impl WriteColor,
+    c: &ColorSpec,
+    is_last_row: bool,
+) -> ViuResult {
+    let out_color;
+    let out_char;
+    let mut new_color;
+
+    // On the last row use upper blocks and leave the bottom half empty (transparent)
+    if is_last_row {
+        new_color = ColorSpec::new();
+        if let Some(bg) = c.bg() {
+            new_color.set_fg(Some(*bg));
+            out_char = UPPER_HALF_BLOCK;
+        } else {
+            execute!(stdout, MoveRight(1))?;
+            return Ok(());
+        }
+        out_color = &new_color;
+    } else {
+        match (c.fg(), c.bg()) {
+            (None, None) => {
+                // completely transparent
+                execute!(stdout, MoveRight(1))?;
+                return Ok(());
+            }
+            (Some(bottom), None) => {
+                // only top transparent
+                new_color = ColorSpec::new();
+                new_color.set_fg(Some(*bottom));
+                out_color = &new_color;
+                out_char = LOWER_HALF_BLOCK;
+            }
+            (None, Some(top)) => {
+                // only bottom transparent
+                new_color = ColorSpec::new();
+                new_color.set_fg(Some(*top));
+                out_color = &new_color;
+                out_char = UPPER_HALF_BLOCK;
+            }
+            (Some(_top), Some(_bottom)) => {
+                // both parts have a color
+                out_color = c;
+                out_char = LOWER_HALF_BLOCK;
+            }
+        }
+    }
+    stdout.set_color(out_color)?;
+    write!(stdout, "{}", out_char)?;
+
+    Ok(())
+}
+
+fn is_pixel_transparent(pixel: (u32, u32, &Rgba<u8>)) -> bool {
+    pixel.2[3] == 0
+}
+
+fn get_transparency_color(row: u32, col: u32, truecolor: bool) -> Color {
+    //imitate the transparent chess board pattern
+    let rgb = if row % 2 == col % 2 {
+        CHECKERBOARD_BACKGROUND_DARK
+    } else {
+        CHECKERBOARD_BACKGROUND_LIGHT
+    };
+    if truecolor {
+        Color::Rgb(rgb.0, rgb.1, rgb.2)
+    } else {
+        Color::Ansi256(ansi256_from_rgb(rgb))
+    }
+}
+
+fn get_color_from_pixel(pixel: (u32, u32, &Rgba<u8>), truecolor: bool) -> Color {
+    let (_x, _y, data) = pixel;
+    let rgb = (data[0], data[1], data[2]);
+    if truecolor {
+        Color::Rgb(rgb.0, rgb.1, rgb.2)
+    } else {
+        Color::Ansi256(ansi256_from_rgb(rgb))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use termcolor::{Ansi, Color};
+
+    // Note: truecolor is not supported in CI. Hence, it should be disabled when writing the tests
+
+    #[test]
+    fn test_block_printer_e2e() {
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(5, 4));
+        let mut buf = Ansi::new(vec![]);
+
+        let config = Config {
+            truecolor: false,
+            ..Default::default()
+        };
+
+        let (w, h) = print_to_writecolor(&mut buf, &img, &config).unwrap();
+        assert_eq!((w, h), (5, 2));
+
+        assert_eq!(
+            std::str::from_utf8(buf.get_ref()).unwrap(),
+            "\x1b[1;1H\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\x1b[38;5;241m\x1b[48;5;247m▄\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\x1b[38;5;241m\x1b[48;5;247m▄\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\r\n\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\x1b[38;5;241m\x1b[48;5;247m▄\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\x1b[38;5;241m\x1b[48;5;247m▄\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\n"
+        );
+    }
+
+    #[test]
+    fn test_block_printer_e2e_transparent() {
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(5, 4));
+        let mut buf = Ansi::new(vec![]);
+
+        let config = Config {
+            transparent: true,
+            ..Default::default()
+        };
+
+        let (w, h) = print_to_writecolor(&mut buf, &img, &config).unwrap();
+        assert_eq!((w, h), (5, 2));
+
+        assert_eq!(
+            std::str::from_utf8(buf.get_ref()).unwrap(),
+            "\x1b[1;1H\x1b[1C\x1b[1C\x1b[1C\x1b[1C\x1b[1C\x1b[0m\r\n\x1b[1C\x1b[1C\x1b[1C\x1b[1C\x1b[1C\x1b[0m\n"
+        );
+    }
+
+    #[test]
+    fn test_block_printer_e2e_odd_height() {
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(4, 3));
+        let mut buf = Ansi::new(vec![]);
+
+        let config = Config {
+            truecolor: false,
+            absolute_offset: false,
+            ..Default::default()
+        };
+        let (w, h) = print_to_writecolor(&mut buf, &img, &config).unwrap();
+        assert_eq!((w, h), (4, 2));
+
+        assert_eq!(
+            std::str::from_utf8(buf.get_ref()).unwrap(),
+            "\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\x1b[38;5;241m\x1b[48;5;247m▄\x1b[0m\x1b[38;5;247m\x1b[48;5;241m▄\x1b[0m\x1b[38;5;241m\x1b[48;5;247m▄\x1b[0m\r\n\x1b[0m\x1b[38;5;241m▀\x1b[0m\x1b[38;5;247m▀\x1b[0m\x1b[38;5;241m▀\x1b[0m\x1b[38;5;247m▀\x1b[0m\n"
+        );
+    }
+
+    #[test]
+    fn test_write_colored_char_only_fg() {
+        let mut buf = Ansi::new(vec![]);
+        let mut c = ColorSpec::new();
+
+        c.set_fg(Some(Color::Rgb(10, 20, 30)));
+
+        write_colored_character(&mut buf, &c, false).unwrap();
+        assert_eq!(
+            std::str::from_utf8(buf.get_ref()).unwrap(),
+            "\x1b[0m\x1b[38;2;10;20;30m▄"
+        );
+    }
+
+    #[test]
+    fn test_write_colored_char_only_bg() {
+        let mut buf = Ansi::new(vec![]);
+        let mut c = ColorSpec::new();
+
+        c.set_bg(Some(Color::Rgb(50, 60, 70)));
+
+        write_colored_character(&mut buf, &c, false).unwrap();
+        assert_eq!(
+            std::str::from_utf8(buf.get_ref()).unwrap(),
+            "\x1b[0m\x1b[38;2;50;60;70m▀"
+        );
+    }
+
+    #[test]
+    fn test_write_colored_char_fg_and_bg() {
+        let mut buf = Ansi::new(vec![]);
+        let mut c = ColorSpec::new();
+
+        c.set_fg(Some(Color::Rgb(10, 20, 30)));
+        c.set_bg(Some(Color::Rgb(15, 25, 35)));
+
+        write_colored_character(&mut buf, &c, false).unwrap();
+        assert_eq!(
+            std::str::from_utf8(buf.get_ref()).unwrap(),
+            "\x1b[0m\x1b[38;2;10;20;30m\x1b[48;2;15;25;35m▄"
+        );
+    }
+
+    #[test]
+    fn test_write_colored_char_no_color() {
+        let mut buf = Ansi::new(vec![]);
+        let c = ColorSpec::new();
+
+        write_colored_character(&mut buf, &c, false).unwrap();
+        // expect to print nothing, just move cursor to the right
+        assert_eq!(std::str::from_utf8(buf.get_ref()).unwrap(), "\x1b[1C");
+    }
+
+    #[test]
+    fn test_write_colored_char_last_row_bg() {
+        let mut buf = Ansi::new(vec![]);
+        let mut c = ColorSpec::new();
+
+        c.set_bg(Some(Color::Rgb(10, 20, 30)));
+
+        write_colored_character(&mut buf, &c, true).unwrap();
+        assert_eq!(
+            std::str::from_utf8(buf.get_ref()).unwrap(),
+            "\x1b[0m\x1b[38;2;10;20;30m▀"
+        );
+    }
+
+    #[test]
+    fn test_write_colored_char_last_row_no_bg() {
+        let mut buf = Ansi::new(vec![]);
+        let mut c = ColorSpec::new();
+
+        // test with no color
+        write_colored_character(&mut buf, &c, true).unwrap();
+        assert_eq!(std::str::from_utf8(buf.get_ref()).unwrap(), "\x1b[1C");
+
+        c.set_fg(Some(Color::Rgb(10, 20, 30)));
+
+        // test with fg (unusual case)
+        let mut buf = Ansi::new(vec![]);
+        write_colored_character(&mut buf, &c, true).unwrap();
+        assert_eq!(std::str::from_utf8(buf.get_ref()).unwrap(), "\x1b[1C");
+    }
+}

--- a/src/viuer/printer/iterm.rs
+++ b/src/viuer/printer/iterm.rs
@@ -1,6 +1,7 @@
 use crate::viuer::error::ViuResult;
 use crate::viuer::printer::{adjust_offset, find_best_fit, Printer};
 use crate::viuer::Config;
+use base64::{engine::general_purpose, Engine as _};
 use image::{DynamicImage, GenericImageView, ImageEncoder};
 use lazy_static::lazy_static;
 use std::{
@@ -77,7 +78,7 @@ fn print_buffer(
         w,
         h,
         img_content.len(),
-        base64::encode(img_content)
+        general_purpose::STANDARD.encode(img_content)
     )?;
     stdout.flush()?;
 

--- a/src/viuer/printer/iterm.rs
+++ b/src/viuer/printer/iterm.rs
@@ -73,10 +73,10 @@ fn print_buffer(
 
     writeln!(
         stdout,
-        "\x1b]1337;File=inline=1;preserveAspectRatio=1;size={};width={};height={}:{}\x07",
-        img_content.len(),
+        "\x1b]1337;File=inline=1;preserveAspectRatio=1;width={};height={};size={}:{}\x07",
         w,
         h,
+        img_content.len(),
         base64::encode(img_content)
     )?;
     stdout.flush()?;
@@ -117,6 +117,11 @@ mod tests {
         let mut vec = Vec::new();
 
         assert_eq!(iTermPrinter.print(&mut vec, &img, &config).unwrap(), (2, 2));
-        assert_eq!(std::str::from_utf8(&vec).unwrap(), "\x1b[4;5H\x1b]1337;File=inline=1;preserveAspectRatio=1;size=71;width=2;height=2:iVBORw0KGgoAAAANSUhEUgAAAAIAAAADCAYAAAC56t6BAAAADklEQVR4AWPADphY2DgAAEMAFfOuwskAAAAASUVORK5CYII=\x07\n");
+
+        let output = std::str::from_utf8(&vec).unwrap();
+        assert!(output.starts_with(
+            "\u{1b}[4;5H\u{1b}]1337;File=inline=1;preserveAspectRatio=1;width=2;height=2;size="
+        ));
+        assert!(output.ends_with("\u{07}\n"));
     }
 }

--- a/src/viuer/printer/iterm.rs
+++ b/src/viuer/printer/iterm.rs
@@ -1,0 +1,122 @@
+use crate::viuer::error::ViuResult;
+use crate::viuer::printer::{adjust_offset, find_best_fit, Printer};
+use crate::viuer::Config;
+use image::{DynamicImage, GenericImageView, ImageEncoder};
+use lazy_static::lazy_static;
+use std::{
+    io::{BufReader, Read, Write},
+    path::Path,
+};
+
+#[allow(non_camel_case_types)]
+pub struct iTermPrinter;
+
+lazy_static! {
+    static ref ITERM_SUPPORT: bool = check_iterm_support();
+}
+
+/// Returns the terminal's support for the iTerm graphics protocol.
+pub fn is_iterm_supported() -> bool {
+    *ITERM_SUPPORT
+}
+
+impl Printer for iTermPrinter {
+    fn print(
+        &self,
+        stdout: &mut impl Write,
+        img: &DynamicImage,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
+        let (width, height) = img.dimensions();
+
+        // Transform the dynamic image to a PNG which can be given directly to iTerm
+        let mut png_bytes: Vec<u8> = Vec::new();
+        image::codecs::png::PngEncoder::new(&mut png_bytes).write_image(
+            img.as_bytes(),
+            width,
+            height,
+            img.color(),
+        )?;
+
+        print_buffer(stdout, img, &png_bytes[..], config)
+    }
+
+    fn print_from_file<P: AsRef<Path>>(
+        &self,
+        stdout: &mut impl Write,
+        filename: P,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
+        let file = std::fs::File::open(filename)?;
+
+        // load the file content
+        let mut buf_reader = BufReader::new(file);
+        let mut file_content = Vec::new();
+        buf_reader.read_to_end(&mut file_content)?;
+
+        let img = image::load_from_memory(&file_content[..])?;
+        print_buffer(stdout, &img, &file_content[..], config)
+    }
+}
+
+// This function requires both a DynamicImage, which is used to calculate dimensions,
+// and it's raw representation as a file, because that's the data iTerm needs to display it.
+fn print_buffer(
+    stdout: &mut impl Write,
+    img: &DynamicImage,
+    img_content: &[u8],
+    config: &Config,
+) -> ViuResult<(u32, u32)> {
+    adjust_offset(stdout, config)?;
+
+    let (w, h) = find_best_fit(img, config.width, config.height);
+
+    writeln!(
+        stdout,
+        "\x1b]1337;File=inline=1;preserveAspectRatio=1;size={};width={};height={}:{}\x07",
+        img_content.len(),
+        w,
+        h,
+        base64::encode(img_content)
+    )?;
+    stdout.flush()?;
+
+    Ok((w, h))
+}
+
+// Check if the iTerm protocol can be used
+fn check_iterm_support() -> bool {
+    if let Ok(term) = std::env::var("TERM_PROGRAM") {
+        if term.contains("iTerm") || term.contains("WezTerm") || term.contains("mintty") {
+            return true;
+        }
+    }
+    if let Ok(lc_term) = std::env::var("LC_TERMINAL") {
+        if lc_term.contains("iTerm") || lc_term.contains("WezTerm") || lc_term.contains("mintty") {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::GenericImage;
+
+    #[test]
+    fn test_print_e2e() {
+        let mut img = DynamicImage::ImageRgba8(image::RgbaImage::new(2, 3));
+        img.put_pixel(1, 2, image::Rgba([2, 4, 6, 8]));
+
+        let config = Config {
+            x: 4,
+            y: 3,
+            ..Default::default()
+        };
+        let mut vec = Vec::new();
+
+        assert_eq!(iTermPrinter.print(&mut vec, &img, &config).unwrap(), (2, 2));
+        assert_eq!(std::str::from_utf8(&vec).unwrap(), "\x1b[4;5H\x1b]1337;File=inline=1;preserveAspectRatio=1;size=71;width=2;height=2:iVBORw0KGgoAAAANSUhEUgAAAAIAAAADCAYAAAC56t6BAAAADklEQVR4AWPADphY2DgAAEMAFfOuwskAAAAASUVORK5CYII=\x07\n");
+    }
+}

--- a/src/viuer/printer/kitty.rs
+++ b/src/viuer/printer/kitty.rs
@@ -1,0 +1,249 @@
+use crate::viuer::error::{ViuError, ViuResult};
+use crate::viuer::printer::{adjust_offset, find_best_fit, Printer};
+use crate::viuer::Config;
+use console::{Key, Term};
+use lazy_static::lazy_static;
+use std::io::Write;
+use std::io::{Error, ErrorKind};
+
+pub struct KittyPrinter;
+
+const TEMP_FILE_PREFIX: &str = ".tty-graphics-protocol.viuer.";
+lazy_static! {
+    static ref KITTY_SUPPORT: KittySupport = check_kitty_support();
+}
+
+/// Returns the terminal's support for the Kitty graphics protocol.
+pub fn get_kitty_support() -> KittySupport {
+    *KITTY_SUPPORT
+}
+
+impl Printer for KittyPrinter {
+    fn print(
+        &self,
+        stdout: &mut impl Write,
+        img: &image::DynamicImage,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
+        match get_kitty_support() {
+            KittySupport::None => Err(ViuError::KittyNotSupported),
+            KittySupport::Local => {
+                // print from file
+                print_local(stdout, img, config)
+            }
+            KittySupport::Remote => {
+                // print through escape codes
+                print_remote(stdout, img, config)
+            }
+        }
+    }
+
+    // TODO: guess_format() here in order to treat PNGs specially (f=100).
+    // Also, maybe get channel count and use f=24 or f=32 accordingly.
+    // fn print_from_file(&self, filename: &str, config: &Config) -> ViuResult<(u32, u32)> {}
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+/// The extend to which the Kitty graphics protocol can be used.
+pub enum KittySupport {
+    /// The Kitty graphics protocol is not supported.
+    None,
+    /// Kitty is running locally, data can be shared through a file.
+    Local,
+    /// Kitty is not running locally, data has to be sent through escape codes.
+    Remote,
+}
+
+// Check if Kitty protocol can be used
+fn check_kitty_support() -> KittySupport {
+    if let Ok(term) = std::env::var("TERM") {
+        if term.contains("kitty") {
+            if has_local_support().is_ok() {
+                return KittySupport::Local;
+            } else {
+                return KittySupport::Remote;
+            }
+        }
+    }
+    KittySupport::None
+}
+
+// Query the terminal whether it can display an image from a file
+fn has_local_support() -> ViuResult {
+    // create a temp file that will hold a 1x1 image
+    let x = image::RgbaImage::new(1, 1);
+    let raw_img = x.as_raw();
+    let path = store_in_tmp_file(raw_img)?;
+
+    // send the query
+    print!(
+        // t=t tells Kitty it's reading from a temp file and will delete if afterwards
+        "\x1b_Gi=31,s=1,v=1,a=q,t=t;{}\x1b\\",
+        base64::encode(path.to_str().ok_or_else(|| std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Could not convert path to &str"
+        ))?)
+    );
+    std::io::stdout().flush()?;
+
+    // collect Kitty's response after the query
+    let term = Term::stdout();
+    let mut response = Vec::new();
+
+    // TODO: could use a queue of length 3
+    while let Ok(key) = term.read_key() {
+        // The response will end with Esc('x1b'), followed by Backslash('\').
+        // Also, break if the Unknown key is found, which is returned when we're not in a tty
+        let should_break = key == Key::UnknownEscSeq(vec!['\\']) || key == Key::Unknown;
+        response.push(key);
+        if should_break {
+            break;
+        }
+    }
+
+    // Kitty response should end with these 3 Keys if it was successful
+    let expected = [
+        Key::Char('O'),
+        Key::Char('K'),
+        Key::UnknownEscSeq(vec!['\\']),
+    ];
+
+    if response.len() >= expected.len() && response[response.len() - 3..] == expected {
+        return Ok(());
+    }
+
+    Err(ViuError::KittyResponse(response))
+}
+
+// Print with kitty graphics protocol through a temp file
+// TODO: try with kitty's supported compression
+fn print_local(
+    stdout: &mut impl Write,
+    img: &image::DynamicImage,
+    config: &Config,
+) -> ViuResult<(u32, u32)> {
+    let rgba = img.to_rgba8();
+    let raw_img = rgba.as_raw();
+    let path = store_in_tmp_file(raw_img)?;
+
+    adjust_offset(stdout, config)?;
+
+    // get the desired width and height
+    let (w, h) = find_best_fit(img, config.width, config.height);
+
+    write!(
+        stdout,
+        "\x1b_Gf=32,s={},v={},c={},r={},a=T,t=t;{}\x1b\\",
+        img.width(),
+        img.height(),
+        w,
+        h,
+        base64::encode(path.to_str().ok_or_else(|| ViuError::Io(Error::new(
+            ErrorKind::Other,
+            "Could not convert path to &str"
+        )))?)
+    )?;
+    writeln!(stdout)?;
+    stdout.flush()?;
+
+    Ok((w, h))
+}
+
+// Print with escape codes
+// TODO: try compression
+fn print_remote(
+    stdout: &mut impl Write,
+    img: &image::DynamicImage,
+    config: &Config,
+) -> ViuResult<(u32, u32)> {
+    let rgba = img.to_rgba8();
+    let raw = rgba.as_raw();
+    let encoded = base64::encode(raw);
+    let mut iter = encoded.chars().peekable();
+
+    adjust_offset(stdout, config)?;
+
+    let (w, h) = find_best_fit(img, config.width, config.height);
+
+    let first_chunk: String = iter.by_ref().take(4096).collect();
+
+    // write the first chunk, which describes the image
+    write!(
+        stdout,
+        "\x1b_Gf=32,a=T,t=d,s={},v={},c={},r={},m=1;{}\x1b\\",
+        img.width(),
+        img.height(),
+        w,
+        h,
+        first_chunk
+    )?;
+
+    // write all the chunks, each containing 4096 bytes of data
+    while iter.peek().is_some() {
+        let chunk: String = iter.by_ref().take(4096).collect();
+        let m = if iter.peek().is_some() { 1 } else { 0 };
+        write!(stdout, "\x1b_Gm={};{}\x1b\\", m, chunk)?;
+    }
+    writeln!(stdout)?;
+    stdout.flush()?;
+    Ok((w, h))
+}
+
+// Create a file in temporary dir and write the byte slice to it.
+fn store_in_tmp_file(buf: &[u8]) -> std::result::Result<std::path::PathBuf, ViuError> {
+    let (mut tmpfile, path) = tempfile::Builder::new()
+        .prefix(TEMP_FILE_PREFIX)
+        .rand_bytes(1)
+        .tempfile()?
+        // Since the file is persisted, the user is responsible for deleting it afterwards. However,
+        // Kitty does this automatically after printing from a temp file.
+        .keep()?;
+
+    tmpfile.write_all(buf)?;
+    tmpfile.flush()?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{DynamicImage, GenericImage};
+
+    #[test]
+    fn test_print_local() {
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(40, 25));
+        let config = Config {
+            x: 4,
+            y: 3,
+            ..Default::default()
+        };
+
+        let mut vec = Vec::new();
+        assert_eq!(print_local(&mut vec, &img, &config).unwrap(), (40, 13));
+        let result = std::str::from_utf8(&vec).unwrap();
+
+        assert!(result.starts_with("\x1b[4;5H\x1b_Gf=32,s=40,v=25,c=40,r=13,a=T,t=t;"));
+        assert!(result.ends_with("\x1b\\\n"));
+    }
+
+    #[test]
+    fn test_print_remote() {
+        let mut img = DynamicImage::ImageRgba8(image::RgbaImage::new(1, 2));
+        img.put_pixel(0, 1, image::Rgba([2, 4, 6, 8]));
+
+        let config = Config {
+            x: 2,
+            y: 5,
+            ..Default::default()
+        };
+
+        let mut vec = Vec::new();
+        assert_eq!(print_remote(&mut vec, &img, &config).unwrap(), (1, 1));
+        let result = std::str::from_utf8(&vec).unwrap();
+
+        assert_eq!(
+            result,
+            "\x1b[6;3H\x1b_Gf=32,a=T,t=d,s=1,v=2,c=1,r=1,m=1;AAAAAAIEBgg=\x1b\\\n"
+        );
+    }
+}

--- a/src/viuer/printer/mod.rs
+++ b/src/viuer/printer/mod.rs
@@ -1,0 +1,469 @@
+use crate::viuer::config::Config;
+use crate::viuer::error::{ViuError, ViuResult};
+use crate::viuer::utils::terminal_size;
+use crossterm::cursor::{MoveRight, MoveTo, MoveToPreviousLine};
+use crossterm::execute;
+use image::{DynamicImage, GenericImageView};
+use std::{io::Write, path::Path};
+
+mod block;
+pub use block::BlockPrinter;
+
+mod kitty;
+pub use kitty::{get_kitty_support, KittyPrinter, KittySupport};
+
+#[cfg(feature = "sixel")]
+mod sixel;
+#[cfg(feature = "sixel")]
+pub use self::sixel::{is_sixel_supported, SixelPrinter};
+
+mod iterm;
+pub use iterm::iTermPrinter;
+pub use iterm::is_iterm_supported;
+
+pub trait Printer {
+    // Print the given image in the terminal while respecting the options in the config struct.
+    // Return the dimensions of the printed image in **terminal cells**.
+    fn print(
+        &self,
+        stdout: &mut impl Write,
+        img: &DynamicImage,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)>;
+    fn print_from_file<P: AsRef<Path>>(
+        &self,
+        stdout: &mut impl Write,
+        filename: P,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
+        let img = image::io::Reader::open(filename)?
+            .with_guessed_format()?
+            .decode()?;
+        self.print(stdout, &img, config)
+    }
+}
+
+#[allow(non_camel_case_types)]
+pub enum PrinterType {
+    Block,
+    Kitty,
+    iTerm,
+    #[cfg(feature = "sixel")]
+    Sixel,
+}
+
+impl Printer for PrinterType {
+    fn print(
+        &self,
+        stdout: &mut impl Write,
+        img: &DynamicImage,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
+        match self {
+            PrinterType::Block => BlockPrinter.print(stdout, img, config),
+            PrinterType::Kitty => KittyPrinter.print(stdout, img, config),
+            PrinterType::iTerm => iTermPrinter.print(stdout, img, config),
+            #[cfg(feature = "sixel")]
+            PrinterType::Sixel => SixelPrinter.print(stdout, img, config),
+        }
+    }
+
+    fn print_from_file<P: AsRef<Path>>(
+        &self,
+        stdout: &mut impl Write,
+        filename: P,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
+        match self {
+            PrinterType::Block => BlockPrinter.print_from_file(stdout, filename, config),
+            PrinterType::Kitty => KittyPrinter.print_from_file(stdout, filename, config),
+            PrinterType::iTerm => iTermPrinter.print_from_file(stdout, filename, config),
+            #[cfg(feature = "sixel")]
+            PrinterType::Sixel => SixelPrinter.print_from_file(stdout, filename, config),
+        }
+    }
+}
+
+/// Resize a [image::DynamicImage] so that it fits within optional width and height bounds.
+/// If none are provided, terminal size is used instead.
+pub fn resize(img: &DynamicImage, width: Option<u32>, height: Option<u32>) -> DynamicImage {
+    let (w, h) = find_best_fit(img, width, height);
+
+    // find_best_fit returns values in terminal cells. Hence, we multiply by two
+    // because a 5x10 image can fit in 5x5 cells. However, a 5x9 image will also
+    // fit in 5x5 and 1 is deducted in such cases.
+    img.resize_exact(
+        w,
+        2 * h - img.height() % 2,
+        image::imageops::FilterType::Triangle,
+    )
+}
+
+/// Find the best dimensions for the printed image, based on user's input.
+/// Returns the dimensions of how the image should be printed in **terminal cells**.
+///
+/// The behaviour is different based on the provided width and height:
+/// - If both are None, the image will be resized to fit in the terminal. Aspect ratio is preserved.
+/// - If only one is provided and the other is None, it will fit the image in the provided boundary. Aspect ratio is preserved.
+/// - If both are provided, the image will be resized to match the new size. Aspect ratio is **not** preserved.
+///
+/// Example:
+/// Use None for both dimensions to use terminal size (80x24) instead.
+/// The image ratio is 2:1, the terminal can be split into 80x46 squares.
+/// The best fit would be to use the whole width (80) and 40 vertical squares,
+/// which is equivalent to 20 terminal cells.
+///
+/// let img = image::DynamicImage::ImageRgba8(image::RgbaImage::new(160, 80));
+/// let (w, h) = find_best_fit(&img, None, None);
+/// assert_eq!(w, 80);
+/// assert_eq!(h, 20);
+//TODO: it might make more sense to change signiture from img to (width, height)
+fn find_best_fit(img: &DynamicImage, width: Option<u32>, height: Option<u32>) -> (u32, u32) {
+    let (img_width, img_height) = img.dimensions();
+
+    // Match user's width and height preferences
+    match (width, height) {
+        (None, None) => {
+            let (term_w, term_h) = terminal_size();
+            let (w, h) = fit_dimensions(img_width, img_height, term_w as u32, term_h as u32);
+
+            // One less row because two reasons:
+            // - the prompt after executing the command will take a line
+            // - gifs flicker
+            let h = if h == term_h as u32 { h - 1 } else { h };
+            (w, h)
+        }
+        // Either width or height is specified, will fit and preserve aspect ratio.
+        (Some(w), None) => fit_dimensions(img_width, img_height, w, img_height),
+        (None, Some(h)) => fit_dimensions(img_width, img_height, img_width, h),
+
+        // Both width and height are specified, will resize to match exactly
+        (Some(w), Some(h)) => (w, h),
+    }
+}
+
+/// Given width & height of an image, scale the size so that it can fit within given bounds
+/// while preserving aspect ratio. Will only scale down - if dimensions are smaller than the
+/// bounds, they will be returned unmodified.
+///
+/// Note: input bounds are meant to hold dimensions of a terminal, where the height of a cell is
+/// twice it's width. It is best illustrated in an example:
+///
+/// Trying to fit a 100x100 image in 40x15 terminal cells. The best fit, while having an aspect
+/// ratio of 1:1, would be to use all of the available height, 15, which is
+/// equivalent in size to 30 vertical cells. Hence, the returned dimensions will be 30x15.
+///
+/// assert_eq!((30, 15), viuer::fit_dimensions(100, 100, 40, 15));
+fn fit_dimensions(width: u32, height: u32, bound_width: u32, bound_height: u32) -> (u32, u32) {
+    let bound_height = 2 * bound_height;
+
+    if width <= bound_width && height <= bound_height {
+        return (width, std::cmp::max(1, height / 2 + height % 2));
+    }
+
+    let ratio = width * bound_height;
+    let nratio = bound_width * height;
+
+    let use_width = nratio <= ratio;
+    let intermediate = if use_width {
+        height * bound_width / width
+    } else {
+        width * bound_height / height
+    };
+
+    if use_width {
+        (bound_width, std::cmp::max(1, intermediate / 2))
+    } else {
+        (intermediate, std::cmp::max(1, bound_height / 2))
+    }
+}
+
+// Move the cursor to a location from where it should start printing. Calculations are based on
+// offsets from the config.
+fn adjust_offset(stdout: &mut impl Write, config: &Config) -> ViuResult {
+    if config.absolute_offset {
+        if config.y >= 0 {
+            // If absolute_offset, move to (x,y).
+            execute!(stdout, MoveTo(config.x, config.y as u16))?;
+        } else {
+            //Negative values do not make sense.
+            return Err(ViuError::InvalidConfiguration(
+                "absolute_offset is true but y offset is negative".to_owned(),
+            ));
+        }
+    } else {
+        if config.y < 0 {
+            // MoveUp if negative
+            execute!(stdout, MoveToPreviousLine(-config.y as u16))?;
+        } else {
+            // Move down y lines
+            for _ in 0..config.y {
+                // writeln! is used instead of MoveDown to force scrolldown
+                // observed when config.y > 0 and cursor is on the last terminal line
+                writeln!(stdout)?;
+            }
+        }
+
+        // Some terminals interpret 0 as 1, see MoveRight documentation
+        if config.x > 0 {
+            execute!(stdout, MoveRight(config.x))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_adjust_offset_output(config: &Config, str: &str) {
+        let mut vec = Vec::new();
+        adjust_offset(&mut vec, config).unwrap();
+        assert_eq!(std::str::from_utf8(&vec).unwrap(), str);
+    }
+
+    fn best_fit_large_test_image() -> DynamicImage {
+        DynamicImage::ImageRgba8(image::RgbaImage::new(600, 499))
+    }
+
+    fn best_fit_small_test_image() -> DynamicImage {
+        DynamicImage::ImageRgba8(image::RgbaImage::new(40, 25))
+    }
+
+    fn resize_get_large_test_image() -> DynamicImage {
+        DynamicImage::ImageRgba8(image::RgbaImage::new(1000, 799))
+    }
+
+    fn resize_get_small_test_image() -> DynamicImage {
+        DynamicImage::ImageRgba8(image::RgbaImage::new(20, 10))
+    }
+
+    // Resize tests
+
+    #[test]
+    fn test_resize_none() {
+        let width = None;
+        let height = None;
+
+        let img = resize_get_large_test_image();
+        let new_img = resize(&img, width, height);
+        assert_eq!(new_img.width(), 60);
+        assert_eq!(new_img.height(), 45);
+
+        let img = resize_get_small_test_image();
+        let new_img = resize(&img, width, height);
+        assert_eq!(new_img.width(), 20);
+        assert_eq!(new_img.height(), 10);
+    }
+
+    #[test]
+    fn test_resize_some_none() {
+        let width = Some(100);
+        let height = None;
+
+        let img = resize_get_large_test_image();
+        let new_img = resize(&img, width, height);
+        assert_eq!(new_img.width(), 100);
+        assert_eq!(new_img.height(), 77);
+
+        let img = resize_get_small_test_image();
+        let new_img = resize(&img, width, height);
+        assert_eq!(new_img.width(), 20);
+        assert_eq!(new_img.height(), 10);
+    }
+
+    #[test]
+    fn test_resize_none_some() {
+        let width = None;
+        let mut height = Some(90);
+
+        let img = resize_get_large_test_image();
+        let new_img = resize(&img, width, height);
+        assert_eq!(new_img.width(), 225);
+        assert_eq!(new_img.height(), 179);
+
+        height = Some(4);
+        let img = resize_get_small_test_image();
+        let new_img = resize(&img, width, height);
+        assert_eq!(new_img.width(), 16);
+        assert_eq!(new_img.height(), 8);
+    }
+
+    #[test]
+    fn test_resize_some_some() {
+        let width = Some(15);
+        let height = Some(9);
+
+        let img = resize_get_large_test_image();
+        let new_img = resize(&img, width, height);
+        assert_eq!(new_img.width(), 15);
+        assert_eq!(new_img.height(), 17);
+
+        let img = resize_get_small_test_image();
+        let new_img = resize(&img, width, height);
+        assert_eq!(new_img.width(), 15);
+        assert_eq!(new_img.height(), 18);
+    }
+
+    // Best fit tests
+
+    #[test]
+    fn find_best_fit_none() {
+        let width = None;
+        let height = None;
+
+        let img = best_fit_large_test_image();
+        let (w, h) = find_best_fit(&img, width, height);
+        assert_eq!(w, 57);
+        assert_eq!(h, 23);
+
+        let img = best_fit_small_test_image();
+        let (w, h) = find_best_fit(&img, width, height);
+        assert_eq!(w, 40);
+        assert_eq!(h, 13);
+
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::new(160, 80));
+        let (w, h) = find_best_fit(&img, width, height);
+        assert_eq!(w, 80);
+        assert_eq!(h, 20);
+    }
+
+    #[test]
+    fn find_best_fit_some_none() {
+        let width = Some(100);
+        let height = None;
+
+        let img = best_fit_large_test_image();
+        let (w, h) = find_best_fit(&img, width, height);
+        assert_eq!(w, 100);
+        assert_eq!(h, 41);
+
+        let img = best_fit_small_test_image();
+        let (w, h) = find_best_fit(&img, width, height);
+        assert_eq!(w, 40);
+        assert_eq!(h, 13);
+
+        let width = Some(6);
+        let (w, h) = find_best_fit(&img, width, height);
+        assert_eq!(w, 6);
+        assert_eq!(h, 1);
+
+        let width = Some(3);
+        let (w, h) = find_best_fit(&img, width, height);
+        assert_eq!(w, 3);
+        assert_eq!(h, 1);
+    }
+
+    #[test]
+    fn find_best_fit_none_some() {
+        let width = None;
+        let height = Some(90);
+
+        let img = best_fit_large_test_image();
+        let (w, h) = find_best_fit(&img, width, height);
+        assert_eq!(w, 216);
+        assert_eq!(h, 90);
+
+        let height = Some(4);
+        let img = best_fit_small_test_image();
+        let (w, h) = find_best_fit(&img, width, height);
+        assert_eq!(w, 12);
+        assert_eq!(h, 4);
+    }
+
+    #[test]
+    fn find_best_fit_some_some() {
+        let width = Some(15);
+        let height = Some(9);
+
+        let img = best_fit_large_test_image();
+        let (w, h) = find_best_fit(&img, width, height);
+        assert_eq!(w, 15);
+        assert_eq!(h, 9);
+
+        let img = best_fit_small_test_image();
+        let (w, h) = find_best_fit(&img, width, height);
+        assert_eq!(w, 15);
+        assert_eq!(h, 9);
+    }
+
+    #[test]
+    fn test_fit_dimensions() {
+        // ratio 1:1
+        assert_eq!((40, 20), fit_dimensions(100, 100, 40, 50));
+        assert_eq!((20, 10), fit_dimensions(100, 100, 40, 10));
+        // ratio 3:2
+        assert_eq!((30, 10), fit_dimensions(240, 160, 30, 100));
+        // ratio 5:7
+        assert_eq!((200, 140), fit_dimensions(300, 420, 320, 140));
+    }
+
+    #[test]
+    fn test_fit_smaller_than_bounds() {
+        assert_eq!((4, 2), fit_dimensions(4, 3, 80, 24));
+        assert_eq!((4, 1), fit_dimensions(4, 1, 80, 24));
+    }
+
+    #[test]
+    fn test_fit_equal_to_bounds() {
+        assert_eq!((80, 12), fit_dimensions(80, 24, 80, 24));
+    }
+
+    #[test]
+    fn test_zero_offset() {
+        let config = Config {
+            absolute_offset: false,
+            x: 0,
+            y: 0,
+            ..Default::default()
+        };
+        // Should not move at all
+        test_adjust_offset_output(&config, "");
+    }
+
+    #[test]
+    fn test_adjust_offset_absolute() {
+        let mut config = Config {
+            absolute_offset: true,
+            x: 3,
+            y: 4,
+            ..Default::default()
+        };
+
+        config.x = 3;
+        config.y = 0;
+        test_adjust_offset_output(&config, "\x1b[1;4H");
+
+        config.x = 7;
+        config.y = 4;
+        test_adjust_offset_output(&config, "\x1b[5;8H");
+    }
+
+    #[test]
+    fn test_adjust_offset_not_absolute() {
+        let mut config = Config {
+            absolute_offset: false,
+            x: 3,
+            y: 4,
+            ..Default::default()
+        };
+        test_adjust_offset_output(&config, "\n\n\n\n\x1b[3C");
+
+        config.x = 1;
+        config.y = -2;
+        test_adjust_offset_output(&config, "\x1b[2F\x1b[1C");
+    }
+
+    #[test]
+    fn test_invalid_adjust_offset() {
+        let config = Config {
+            absolute_offset: true,
+            y: -1,
+            ..Default::default()
+        };
+
+        let mut vec = Vec::new();
+        let err = adjust_offset(&mut vec, &config).unwrap_err();
+        assert!(matches!(err, ViuError::InvalidConfiguration { .. }));
+    }
+}

--- a/src/viuer/printer/sixel.rs
+++ b/src/viuer/printer/sixel.rs
@@ -1,0 +1,97 @@
+use crate::error::ViuResult;
+use crate::printer::{adjust_offset, find_best_fit, Printer};
+use crate::Config;
+use console::{Key, Term};
+use image::{imageops::FilterType, DynamicImage, GenericImageView};
+use lazy_static::lazy_static;
+use sixel_rs::encoder::{Encoder, QuickFrameBuilder};
+use sixel_rs::optflags::EncodePolicy;
+use std::io::Write;
+
+pub struct SixelPrinter;
+
+lazy_static! {
+    static ref SIXEL_SUPPORT: bool = check_sixel_support();
+}
+
+/// Returns the terminal's support for Sixel.
+pub fn is_sixel_supported() -> bool {
+    *SIXEL_SUPPORT
+}
+
+impl Printer for SixelPrinter {
+    fn print(
+        &self,
+        stdout: &mut impl Write,
+        img: &DynamicImage,
+        config: &Config,
+    ) -> ViuResult<(u32, u32)> {
+        let (w, h) = find_best_fit(img, config.width, config.height);
+
+        //TODO: the max 1000 width is an xterm bug workaround, other terminals may not be affected
+        let resized_img =
+            img.resize_exact(std::cmp::min(6 * w, 1000), 12 * h, FilterType::Triangle);
+
+        let (width, height) = resized_img.dimensions();
+
+        let rgba = resized_img.to_rgba8();
+        let raw = rgba.as_raw();
+
+        adjust_offset(stdout, config)?;
+
+        let encoder = Encoder::new()?;
+
+        encoder.set_encode_policy(EncodePolicy::Fast)?;
+
+        let frame = QuickFrameBuilder::new()
+            .width(width as usize)
+            .height(height as usize)
+            .format(sixel_rs::sys::PixelFormat::RGBA8888)
+            .pixels(raw.to_vec());
+
+        encoder.encode_bytes(frame)?;
+
+        Ok((w, h))
+    }
+}
+
+// Check if Sixel is within the terminal's attributes
+// see https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Sixel-Graphics
+// and https://vt100.net/docs/vt510-rm/DA1.html
+fn check_device_attrs() -> ViuResult<bool> {
+    let mut term = Term::stdout();
+
+    write!(&mut term, "\x1b[c")?;
+    term.flush()?;
+
+    let mut response = String::new();
+
+    while let Ok(key) = term.read_key() {
+        if let Key::Char(c) = key {
+            response.push(c);
+            if c == 'c' {
+                break;
+            }
+        }
+    }
+
+    Ok(response.contains(";4;") || response.contains(";4c"))
+}
+
+// Check if Sixel protocol can be used
+fn check_sixel_support() -> bool {
+    if let Ok(term) = std::env::var("TERM") {
+        match term.as_str() {
+            "mlterm" | "yaft-256color" | "foot" | "foot-extra" => return true,
+            "st-256color" | "xterm" | "xterm-256color" => {
+                return check_device_attrs().unwrap_or(false)
+            }
+            _ => {
+                if let Ok(term_program) = std::env::var("TERM_PROGRAM") {
+                    return term_program == "MacTerm";
+                }
+            }
+        }
+    }
+    false
+}

--- a/src/viuer/utils.rs
+++ b/src/viuer/utils.rs
@@ -1,0 +1,60 @@
+use std::env;
+
+const DEFAULT_TERM_SIZE: (u16, u16) = (80, 24);
+
+pub fn truecolor_available() -> bool {
+    if let Ok(value) = env::var("COLORTERM") {
+        value.contains("truecolor") || value.contains("24bit")
+    } else {
+        false
+    }
+}
+
+/// Try to get the terminal size. If unsuccessful, fallback to a default (80x24).
+///
+/// Uses [crossterm::terminal::size].
+/// ## Example
+/// The example below prints "img.jpg" with dimensions 80x40 in the center of the terminal.
+/// ```no_run
+/// use viuer::{Config, print_from_file, terminal_size};
+///
+/// let (term_width, term_height) = terminal_size();
+/// // Set desired image dimensions
+/// let width = 80;
+/// let height = 40;
+///
+/// let config = Config {
+///     x: (term_width - width) / 2,
+///     y: (term_height - height) as i16 / 2,
+///     width: Some(width as u32),
+///     height: Some(height as u32),
+///     ..Default::default()
+/// };
+/// print_from_file("img.jpg", &config).expect("Image printing failed.");
+/// ```
+#[cfg(not(test))]
+pub fn terminal_size() -> (u16, u16) {
+    match crossterm::terminal::size() {
+        Ok(s) => s,
+        Err(_) => DEFAULT_TERM_SIZE,
+    }
+}
+
+// Return a constant when running the tests
+#[cfg(test)]
+pub fn terminal_size() -> (u16, u16) {
+    DEFAULT_TERM_SIZE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truecolor() {
+        env::set_var("COLORTERM", "truecolor");
+        assert!(truecolor_available());
+        env::set_var("COLORTERM", "");
+        assert!(!truecolor_available());
+    }
+}

--- a/src/viuer/utils.rs
+++ b/src/viuer/utils.rs
@@ -15,7 +15,7 @@ pub fn truecolor_available() -> bool {
 /// Uses [crossterm::terminal::size].
 /// ## Example
 /// The example below prints "img.jpg" with dimensions 80x40 in the center of the terminal.
-/// ```no_run
+/// ```ignore
 /// use viuer::{Config, print_from_file, terminal_size};
 ///
 /// let (term_width, term_height) = terminal_size();


### PR DESCRIPTION
Currently the latest release of viuer will end up not deleting temp files with kitty. After all temp files are generated viuer will hang. This leads to uiua hanging as well.

Luckily, the fix is simple. Kitty will delete temp files if their name contains `tty-graphics-protocol`. More details in https://github.com/atanunq/viuer/pull/51 (this is a 1 line change to a temp file name)

Since the viuer maintainer has been completely inactive on git since November last year, this PR updates uiua to depend on pull 51. This enables uiua to work on kitty without requiring the viuer maintainer to accept the PR and cut a new release.