### PR TITLE
Fix 'nix build' on Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,10 @@
       craneLib = crane.lib.${system};
       uiua-crate = craneLib.buildPackage {
         src = craneLib.cleanCargoSource (craneLib.path ./.);
+         buildInputs = nixpkgs.lib.optionals pkgs.stdenv.isDarwin [
+           pkgs.iconv
+           pkgs.darwin.apple_sdk.frameworks.CoreServices
+        ];
       };
     in
       {


### PR DESCRIPTION
Hi,
Thank you for adding flake.nix.
But `nix build` fails on Darwin.
This PR fixes this issue by adding an extra dependency.

<details>
<summary>
log of 'nix build'
</summary>
<pre>
$ nix build
error: builder for '/nix/store/29m6isag648vgkavgvmrvzk8sajvkdgz-uiua-0.0.5.drv' failed with exit code 101;
       last 10 log lines:
       >    Compiling tower-lsp v0.19.0
       >    Compiling uiua v0.0.5 (/private/tmp/nix-build-uiua-0.0.5.drv-1/5m48ldmyk35znwvmjhdj7zmv817q7j2l-source)
       > error: linking with `/nix/store/ybr7a0lvp4dzr14f1l3882x5qb68vkls-clang-wrapper-11.1.0/bin/cc` failed: exit status: 1
       >   |
       >   = note: LC_ALL="C" PATH="/nix/store/s71dj54b3q0594sis3vp4hl2mdbnn6p3-rustc-1.72.0/lib/rustlib/aarch64-apple-darwin/bin:/nix/store/8mdcavvgk4jf5blq6mspls97iki29l38-cargo-1.72.0/bin:/nix/store/8057g3ixa1i7bxbs43xpgydydl4avsgp-cargo-auditable-0.6.1/bin:/nix/store/qnfrjk7bpxanl6s60y2197q0r782h9q5-auditable-cargo-1.72.0/bin:/nix/store/8mdcavvgk4jf5blq6mspls97iki29l38-cargo-1.72.0/bin:/nix/store/s71dj54b3q0594sis3vp4hl2mdbnn6p3-rustc-1.72.0/bin:/nix/store/ybr7a0lvp4dzr14f1l3882x5qb68vkls-clang-wrapper-11.1.0/bin:/nix/store/6m1ncyha74vyyksinykcsic5gc1b29i7-clang-11.1.0/bin:/nix/store/g9pvwpwpgkhzlq0kv4bbllclm18kv0gj-coreutils-9.3/bin:/nix/store/7yafaqqhz1i9s4jmsj51g28c22yhq3kq-cctools-binutils-darwin-wrapper-11.1.0-973.0.1/bin:/nix/store/5v4ycnqpfammvlwpadyc26by7hy604cz-cctools-binutils-darwin-11.1.0-973.0.1/bin:/nix/store/g9pvwpwpgkhzlq0kv4bbllclm18kv0gj-coreutils-9.3/bin:/nix/store/cnjxsppdzfbwvmkdrkpps6j75a2xqgks-findutils-4.9.0/bin:/nix/store/fmb75iiyrc7bhr0al97izqch5pzrh5dy-diffutils-3.10/bin:/nix/store/c9606i14wkrcjavx5kvhaghxfpgy204k-gnused-4.9/bin:/nix/store/xrqvjyn24z6ljnh9583c13iarks1faa3-gnugrep-3.11/bin:/nix/store/gg71r49xcnn2l565cwz11ws3q38liwdw-gawk-5.2.2/bin:/nix/store/h1y472wdyk5jn7qsgwhcblaj9j42xrx9-gnutar-1.35/bin:/nix/store/5m5mvssdqh2liqz0d6bhjp7sql1bsi62-gzip-1.13/bin:/nix/store/p2i1j2pj8wjmy445xjlcfzq64r7gad50-bzip2-1.0.8-bin/bin:/nix/store/221p2yp3dlb6dxr93iidq4gpx9i25n81-gnumake-4.4.1/bin:/nix/store/zqx1fik7mcyg1037s015kfbw2zq0qhqn-bash-5.2-p15/bin:/nix/store/9ahpbnv7xxyp72f6a08qm0pyrzg85l7x-patch-2.7.6/bin:/nix/store/nws79v3asz8a9cyyn8f76kwykjr6lhkb-xz-5.4.4-bin/bin:/nix/store/f2zhjzawah3klb72plmq79kldymn93gc-file-5.45/bin" VSLANG="1033" ZERO_AR_DATE="1" "/nix/store/ybr7a0lvp4dzr14f1l3882x5qb68vkls-clang-wrapper-11.1.0/bin/cc" "-arch" "arm64" "/private/tmp/nix-build-uiua-0.0.5.drv-1/rustcsD5CDp/symbols.o" "/private/tmp/nix-build-uiua-0.0.5
.drv-1/5m48ldmyk35znwvmjhdj7zmv817q7j2l-source/target/aarch64-apple-darwin/release/deps/uiua-f5366e99923bd407.uiua.9c92564c5eef0ad-cgu.00.rcgu.o" "-L" "/private/tmp/nix-build-uiua-0.0.5.drv-1/5m48ldmyk35znwvmjhdj7zmv817q7j2l-source/target/aarch64-apple-darwin/release/deps" "-L" "/private/tmp/nix-build-uiua-0.0.5.drv-1/5m48ldmyk35znwvmjhdj7zmv817q7j2l-source/target/release/deps" "-L" "/nix/store/s71dj54b3q0594sis3vp4hl2mdbnn6p3-rustc-1.72.0/lib/rustlib/aarch64-apple-darwin/lib" "/nix/store/s71dj54b3q0594sis3vp4hl2mdbnn6p3-rustc-1.72.0/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-9a5dde18cc747729.rlib" "-framework" "CoreFoundation" "-framework" "CoreServices" "-liconv" "-lSystem""-lc" "-lm" "-L" "/nix/store/s71dj54b3q0594sis3vp4hl2mdbnn6p3-rustc-1.72.0/lib/rustlib/aarch64-apple-darwin/lib" "-o" "/private/tmp/nix-build-uiua-0.0.5.drv-1/5m48ldmyk35znwvmjhdj7zmv817q7j2l-source/target/aarch64-apple-darwin/release/deps/uiua-f5366e99923bd407" "-Wl,-dead_strip" "-nodefaultlibs" "/private/tmp/nix-build-uiua-0.0.5.drv-1/5m48ldmyk35znwvmjhdj7zmv817q7j2l-source/target/aarch64-apple-darwin/release/deps/uiua_audit_data.o" "-Wl,-u,_AUDITABLE_VERSION_INFO"
       >   = note: ld: framework not found CoreServices
       >           clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
       >
       >
       > error: could not compile `uiua` (bin "uiua") due to previous error
       For full logs, run 'nix log /nix/store/29m6isag648vgkavgvmrvzk8sajvkdgz-uiua-0.0.5.drv'.
</pre>
</details>
