### PR TITLE
remove roll and unroll from donut example

### DIFF
--- a/examples/donut.ua
+++ b/examples/donut.ua
@@ -14,15 +14,15 @@ cP ← ○+ηP
 Ox ← +Rt×Ro cT
 Oy ← ×Ro sT
 
-calcX ← -∶⊞×Ox+×cP○+η;↷××sP○,○,↷××Oy○+η,○,
-calcY ← +⊞×Ox-∶×cP○;↷××sP○,○+η,↷××Oy○+η,○+η,
-calcOoz ← ÷∶1++Kt ×⊞×Ox sP○+η∶×Oy○.
-calcL ← ↥0↧1×0.7+++×○+η↶+×sT○+η∶¯×↶○.∶↷¯×↷.⊞×cT sP○+η.↷¯×sT○.↷×⊞×cT cP ○,
+calcX ← ♭+→(¯××Oy○∶○+η)⊞×Ox+→(××sP○,○,)×cP○+η,
+calcY ← ♭+→(××Oy○+η∶○+η)⊞×Ox+→(¯××sP○,○+η,)×cP○,
+calcOoz ← ♭÷∶1++Kt ×⊞×Ox sP○+η∶×Oy○.
+calcL ← ♭↥0↧1×0.7+¯×○+η∶→(∶+→(×⊞×cT cP○∶)+→(¯×sT ○.)×→(○+η,)+×sT○+η,¯×○,).⊞×cT sP
 
 Render ← (
-  ↷⁅+150 ××Ko ∶↶calcOoz.∶calcX,,
-  ↷×320⁅-∶120 ××Ko ∶↶calcOoz.∶calcY,,
-  &ims↯ 240_320 ⍛0↙ ×320 240⊕(↥0/↥)♭+↷♭calcL
+  ⁅+150 ××Ko calcOoz,calcX,,
+  →(×320⁅-∶120 ××Ko calcOoz,calcY,,)
+  ↯ 240_320 ⍛0↙ ×320 240⊕(↥0/↥)→calcL+
 )
 
-;;⍥(∶+0.01∶+0.03 Render,,)∞ 1 1
+;;⍥(∶+0.01∶+0.03 &ims Render,,)∞ 1 1


### PR DESCRIPTION
Just updating to dip. Took a minute to figure it out, but I think this version with dip is easier to follow. Nice to temporarily stash one value while calculating the next. Also rechecked all the math and fixed a bug in how the luminance was calculated.