### PR TITLE
Add "--clear" flag to uiua watch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -333,9 +333,9 @@ fn watch(
             if last_time.elapsed() > Duration::from_millis(100) {
                 if clear {
                     if cfg!(target_os = "windows") {
-                        Command::new("cmd").args(&["/C", "cls"]).status().unwrap();
+                        _ = Command::new("cmd").args(&["/C", "cls"]).status();
                     } else {
-                        Command::new("clear").status().unwrap();
+                        _ = Command::new("clear").status();
                     }
                 }
                 run(&path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use clap::{error::ErrorKind, Parser};
+use colored::Colorize;
 use instant::Instant;
 use notify::{EventKind, RecursiveMode, Watcher};
 use once_cell::sync::Lazy;
@@ -53,6 +54,7 @@ fn run() -> UiuaResult {
         uiua::profile::run_profile();
         return Ok(());
     }
+    show_update_message();
     match App::try_parse() {
         Ok(app) => {
             let config = FormatConfig::default();
@@ -448,4 +450,39 @@ fn clear_watching_with(s: &str, end: &str) {
         s.repeat(term_size::dimensions().map_or(10, |(w, _)| w)),
         end,
     );
+}
+
+fn show_update_message() {
+    let Ok(output) = Command::new("cargo").args(["search", "uiua"]).output() else {
+        return;
+    };
+    let output = String::from_utf8_lossy(&output.stdout);
+    let Some(remote_version) = output.split('"').nth(1) else {
+        return;
+    };
+    fn parse_version(s: &str) -> Option<Vec<u16>> {
+        let mut nums = Vec::with_capacity(3);
+        for s in s.split('.') {
+            if let Ok(num) = s.parse() {
+                nums.push(num);
+            } else {
+                return None;
+            }
+        }
+        Some(nums)
+    }
+    let local_version = env!("CARGO_PKG_VERSION");
+    if let Some((local, remote)) = parse_version(local_version).zip(parse_version(remote_version)) {
+        if local < remote {
+            println!(
+                "{}\n",
+                format!(
+                    "Update available: {local_version} → {remote_version}\n\
+                Run `cargo install uiua` to update",
+                )
+                .bright_white()
+                .bold()
+            );
+        }
+    }
 }


### PR DESCRIPTION
Add a flag to clear the terminal when a file is changed, while running "uiua watch". This allows for an (optional) better developer experience