### PR TITLE
`&httpsw`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,7 +911,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2385,6 +2385,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "rstml"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2424,6 +2439,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,6 +2486,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "self_cell"
@@ -2723,6 +2770,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -3106,6 +3159,7 @@ dependencies = [
  "enum-iterator",
  "hodaun",
  "hound",
+ "httparse",
  "image",
  "indexmap 1.9.3",
  "instant",
@@ -3114,6 +3168,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rand",
+ "rustls",
  "serde",
  "serde_yaml",
  "term_size",
@@ -3121,6 +3176,7 @@ dependencies = [
  "tokio",
  "tower-lsp",
  "viuer",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3173,6 +3229,12 @@ name = "unsafe-libyaml"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -3335,6 +3397,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "weezl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,10 @@ hodaun.features = ["output", "wav"]
 hodaun.optional = true
 hodaun.version = "0.4.1"
 hound = "3"
+httparse.optional = true
+httparse.version = "1.8.0"
 image.default-features = false
-image.features = [
-  "bmp",
-  "gif",
-  "ico",
-  "jpeg",
-  "png",
-]
+image.features = ["bmp", "gif", "ico", "jpeg", "png"]
 image.version = "0.24.5"
 indexmap.features = ["serde"]
 indexmap.optional = true
@@ -52,6 +48,8 @@ parking_lot = "0.12.1"
 rand.default-features = false
 rand.features = ["small_rng"]
 rand.version = "0.8.5"
+rustls.optional = true
+rustls.version = "0.21.7"
 serde.features = ["derive"]
 serde.optional = true
 serde.version = "1"
@@ -67,15 +65,18 @@ tower-lsp.optional = true
 tower-lsp.version = "0.19.0"
 viuer.optional = true
 viuer.version = "0.6.2"
+webpki-roots.optional = true
+webpki-roots.version = "0.25.0"
 
 [features]
 audio = ["hodaun", "crossbeam-channel", "lockfree"]
 binary = ["ctrlc", "notify", "clap", "color-backtrace", "lsp"]
 debug = []
-default = ["binary", "terminal_image"]
+default = ["binary", "terminal_image", "https"]
 lsp = ["tower-lsp", "tokio"]
 profile = ["crossbeam-channel", "serde", "serde_yaml", "indexmap"]
 terminal_image = ["viuer"]
+https = ["httparse", "rustls", "webpki-roots"]
 
 [[bin]]
 name = "uiua"

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -277,11 +277,23 @@ sys_op! {
     /// Requires the `Host` header to be set.
     /// Using port 443 is recommended for HTTPS.
     ///
-    /// ex: &tcpc "example.com:443"
-    ///   : &httpsget $ GET / HTTP/1.0
-    ///   :           $ Host: example.com
-    ///   :           $ \r\n
-    (2, HttpsGet, "&httpsget", "http - Make an HTTP request"),
+    /// ex: &httpsget "GET /" &tcpc "example.com:443"
+    ///
+    /// It is also possible to put in entire HTTP requests.
+    ///
+    /// ex: socket ← &tcpc "example.com:443"
+    ///   : &httpsw $ GET /api HTTP/1.0
+    ///   :         $ Host: example.com
+    ///   :         $ 
+    ///   :         $ <BODY>
+    /// 
+    /// There are a few things the function tries to automatically fill in
+    /// if it finds they are missing from the request:
+    /// 
+    ///  - 2 trailing newlines (if there is no body)
+    ///  - The HTTP version
+    ///  - The `Host` header is if not defined
+    (2, HttpsWrite, "&httpsw", "http - Make an HTTP request"),
 }
 
 /// A handle to an IO stream
@@ -1532,7 +1544,7 @@ impl SysOp {
                     .tcp_set_write_timeout(handle, timeout)
                     .map_err(|e| env.error(e))?;
             }
-            SysOp::HttpsGet => {
+            SysOp::HttpsWrite => {
                 let http = env
                     .pop(1)?
                     .as_string(env, "HTTP request must be a string")?;

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -990,12 +990,14 @@ fn check_http(mut request: String, hostname: &str) -> Result<String, String> {
     let mut req = httparse::Request::new(&mut headers);
 
     let mut lines = request.lines().collect::<Vec<_>>();
-    let trailing_newline = request.ends_with('\n');
+    let mut trailing_newline = request.ends_with('\n');
 
     // check to make sure theres an empty line somewhere in there. if not, add 2 empty lines
     if !lines.iter().any(|line| line.is_empty()) {
         lines.push("");
         lines.push("");
+        // so we dont unecessarily add another newline
+        trailing_newline = false;
     }
 
     // If the first line doesn't have a version, add one

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -277,14 +277,13 @@ sys_op! {
     /// Requires the `Host` header to be set.
     /// Using port 443 is recommended for HTTPS.
     ///
-    /// ex: &httpsget "GET /" &tcpc "example.com:443"
+    /// ex: &httpsw "GET / " &tcpc "example.com:443"
     ///
     /// It is also possible to put in entire HTTP requests.
     ///
-    /// ex: socket ← &tcpc "example.com:443"
+    /// ex: &tcpc "example.com:443"
     ///   : &httpsw $ GET /api HTTP/1.0
-    ///   :         $ Host: example.com
-    ///   :         $ 
+    ///   :         $ Host: example.com\r\n
     ///   :         $ <BODY>
     /// 
     /// There are a few things the function tries to automatically fill in
@@ -292,7 +291,7 @@ sys_op! {
     /// 
     ///  - 2 trailing newlines (if there is no body)
     ///  - The HTTP version
-    ///  - The `Host` header is if not defined
+    ///  - The `Host` header (if not defined)
     (2, HttpsWrite, "&httpsw", "http - Make an HTTP request"),
 }
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -272,7 +272,7 @@ sys_op! {
     (1, TcpAddr, "&tcpaddr", "tcp - address"),
     /// Make an HTTP request
     ///
-    /// Takes in an 1.0 HTTP request and returns an HTTP response.
+    /// Takes in an 1.x HTTP request and returns an HTTP response.
     ///
     /// Requires the `Host` header to be set.
     /// Using port 443 is recommended for HTTPS.

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -972,7 +972,6 @@ impl SysBackend for NativeSys {
     }
 }
 
-#[cfg(feature = "https")]
 /// Takes an HTTP request, validates it, and fixes it (if possible) by adding
 /// the HTTP version and trailing newlines if they aren't present.
 ///
@@ -985,11 +984,13 @@ impl SysBackend for NativeSys {
 ///     "GET / HTTP/1.0\r\nhost: example.com\r\n\r\n"
 /// )
 /// ```
+#[cfg(feature = "https")]
 fn check_http(mut request: String, hostname: &str) -> Result<String, String> {
     let mut headers = [httparse::EMPTY_HEADER; 64];
     let mut req = httparse::Request::new(&mut headers);
 
     let mut lines = request.lines().collect::<Vec<_>>();
+    let trailing_newline = request.ends_with('\n');
 
     // check to make sure theres an empty line somewhere in there. if not, add 2 empty lines
     if !lines.iter().any(|line| line.is_empty()) {
@@ -1011,6 +1012,9 @@ fn check_http(mut request: String, hostname: &str) -> Result<String, String> {
             + &lines.into_iter().skip(1).collect::<Vec<_>>().join("\r\n");
     } else {
         request = lines.join("\r\n");
+    }
+    if trailing_newline {
+        request += "\r\n";
     }
 
     // Confirm that the request is valid


### PR DESCRIPTION
Alright! After some work it's finished.

Some implementation notes:
 - I ended up naming it `&httpsget`.
 - Parameters (?) Arguments (?) Inputs / Outputs (?) (i have no idea what they're called):
   - It takes in an string as an HTTP request, verifies it with the crate `httparse` (to give slightly more helpful error messages than just timing out)
   - Also takes in a socket so that it can time out, and just seemed cleaner that way. Makes `&httpsget` like a more specialized version of `&w`
   - Outputs a string representing an HTTP response.
 - Uses `rustls` to make the HTTPS requests
 - It needs the `Host` header because I'm pretty sure you can't get the DNS / hostname from a TCP socket (which I need for TLS) and this is probably better than taking another parameter.

I couldn't get the website to run so couldn't verify that the documentation isn't misformatted or something (Though the example in the documentation, even if formatted correctly, *will* just throw an error).

<details>
<summary>Terminal log</summary>

```bash
# wont work (ver sad)
[I] ~/p/c/u/site $ cd ..
[I] ~/p/c/uiua $ uiua run examples/http_server.ua
Server started
Error: Cannot join number array and character array
    ╭─[examples/http_server.ua:33:3]
 33 │   ⊂ bytes $ HTTP/1.1 _
    │   ─  
    │       
────╯
  in ⊂                     at examples/http_server.ua:33:3
  in `response`            at examples/http_server.ua:42:15
  in `servererror`         at examples/http_server.ua:45:3
  in !                     at examples/http_server.ua:45:3
  in `handlepageloaderror` at examples/http_server.ua:47:8
  in ⍣                     at examples/http_server.ua:47:8
  in `page`                at examples/http_server.ua:51:8
```

</details>

Also - this command should be possible to run on the browser. You could allow the creation of a dummy socket that you can't write to normally, but can make https requests through. I'll stop here though.