### PR TITLE
Explain that both can be chained

### DIFF
--- a/src/primitive/defs.rs
+++ b/src/primitive/defs.rs
@@ -979,7 +979,9 @@ primitive!(
     /// ex: [∩+ 1 2 3 4]
     /// ex: [∩(++) 1 2 3 4 5 6]
     ///
-    /// [both]'s glyph is `∩` because, for a function `f`, it is equivalent to `f∶f∶`.
+    /// [both] can also be chained. Every additional [both] doubles the number of arguments taken from the stack.
+    /// ex: [∩∩(□+2) 1 @a 2_3 5]
+    /// ex: [∩∩∩± 1 ¯2 0 42 ¯5 6 7 8 99]
     (2[1], Both, Stack, ("both", '∩')),
     /// Call two functions on two distinct sets of values
     ///


### PR DESCRIPTION
This is what it looks like rendered:

![Screenshot 2023-10-04 at 09 58 43](https://github.com/uiua-lang/uiua/assets/9742635/1e4d04f2-5a57-43d8-9a8d-b5c3a9e2ff80)

Not sure if using constant is too complicated here, but not putting the result in an array caused the output to be four lines long, which was annoying. I added two spaces to separate the groups of two elements each better.