### PR TITLE
Allow internet access during nix build for tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,9 @@
 {
   description = "A stack-based array programming language";
 
+  # this is to allow tests to access the internet during checkPhase
+  nixConfig.sandbox = "relaxed";
+
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.crane = {


### PR DESCRIPTION
`nix build` was broken by the introduction of tests which access the internet. This gets the build working again. Closes #78

This is a bit of a workaround, ideally I think the build should be hermetic, because I'm a nix ideologue. However, at the same time, I don't want to step on any toes.