### PR TITLE
Update URL on run

### DIFF
--- a/site/src/editor.rs
+++ b/site/src/editor.rs
@@ -306,7 +306,7 @@ pub fn Editor<'a>(
                 window()
                     .history()
                     .unwrap()
-                    .push_state_with_url(&JsValue::NULL, "", Some(&format!("/pad?src={encoded}")))
+                    .replace_state_with_url(&JsValue::NULL, "", Some(&format!("/pad?src={encoded}")))
                     .unwrap();
             }
         }

--- a/site/src/editor.rs
+++ b/site/src/editor.rs
@@ -299,6 +299,18 @@ pub fn Editor<'a>(
             code_text
         };
 
+        // Update URL
+        {
+            let encoded = URL_SAFE.encode(&input);
+            if let EditorSize::Pad = size {
+                window()
+                    .history()
+                    .unwrap()
+                    .push_state_with_url(&JsValue::NULL, "", Some(&format!("/pad?src={encoded}")))
+                    .unwrap();
+            }
+        }
+
         // Run code
         set_output.set(view!(<div class="running-text">"Running"</div>).into_view());
         set_timeout(


### PR DESCRIPTION
Since there have been issues with people accidentally leaving the pad and losing their code, this PR just updates the URL every time the code is run. This matches the behavior of `uiua watch`, as run on save and save on run are effectively equivalent.