### PR TITLE
Add debug configuration for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch (Linux or macOS)",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceRoot}/target/debug/uiua",
+            "args": ["eval", "+1 5"],
+            "cwd": "${workspaceRoot}",
+        },
+        {
+            "name": "Launch (Windows)",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/target/debug/uiua.exe",
+            "args": ["eval", "+1 5"],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}",
+            "environment": [],
+            "externalConsole": true
+        },
+    ]
+}


### PR DESCRIPTION
I could only test the Linux and macOS configuration. I copied both from [this article](https://www.forrestthewoods.com/blog/how-to-debug-rust-with-visual-studio-code/) and adapted them slightly.

This file is still in .gitignore, so when people change it (most likely the "args"), it will not show up as changed, which I think is convenient.