### PR TITLE
`&httpsw` fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ once_cell = "1"
 parking_lot = "0.12.1"
 paste = "1.0.14"
 rand = { version = "0.8.5", features = ["small_rng"] }
-rustls = { version = "0.21.7", optional = true, default-features = false }
+rustls = { version = "0.21.7", optional = true, default-features = false, features = ["tls12"] }
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_yaml = { version = "0.9.25", optional = true }
 term_size = "1.0.0-beta1"

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1005,7 +1005,7 @@ fn check_http(mut request: String, hostname: &str) -> Result<String, String> {
         .ok_or("Empty first line")?;
     if !last_token.starts_with("HTTP/") {
         request = first.to_string()
-            + "HTTP/1.0\r\n"
+            + " HTTP/1.0\r\n"
             + &lines.into_iter().skip(1).collect::<Vec<_>>().join("\r\n");
     } else {
         request = lines.join("\r\n");


### PR DESCRIPTION
I noticed after I updated Uiua that `&httpsw` would just freeze, even though it worked on the older versions. After some debugging I tracked down the issue to the `tls12` feature not being enabled on `rustls`.

Also I added a space before the HTTP version insert so `&httpsw "GET /" &tcpc "example.net/443"` works now, and you don't have to put a space after `GET /`