### PR TITLE
implement uiua watch --stdin-file

### DIFF
--- a/site/src/editor.rs
+++ b/site/src/editor.rs
@@ -306,7 +306,11 @@ pub fn Editor<'a>(
                 window()
                     .history()
                     .unwrap()
-                    .replace_state_with_url(&JsValue::NULL, "", Some(&format!("/pad?src={encoded}")))
+                    .replace_state_with_url(
+                        &JsValue::NULL,
+                        "",
+                        Some(&format!("/pad?src={encoded}")),
+                    )
                     .unwrap();
             }
         }


### PR DESCRIPTION
With `uiua run`, you can use standard unix shell redirection to pipe input to a file with `uiua run my_program.ua < input.txt`. However, this doesn't work for `uiua watch` because it needs to repeatedly read from the file (every time the uiua program is re-run) where shell redirection only reads it once: `uiua watch < input.txt` would work fine for the first execution, but on subsequent saves it would not have the full file to read from. This PR allows users to run `uiua watch --stdin-file input.txt` instead, so that input.txt is read every time. Note that it does _not_ watch for changes to the input file, but it _does_ re-load it on each execution in case it has changed (perhaps it would be better to watch the input file too; I'm open to potentially implementing that).