### PR TITLE
Fix `cargo clippy` warnings

### DIFF
--- a/src/algorithm/invert.rs
+++ b/src/algorithm/invert.rs
@@ -465,11 +465,11 @@ where
             (
                 b.iter()
                     .zip(spans.iter().cycle())
-                    .map(|(p, s)| p.clone().as_instr(*s))
+                    .map(|(p, s)| p.as_instr(*s))
                     .collect(),
                 c.iter()
                     .zip(spans.iter().cycle())
-                    .map(|(p, s)| p.clone().as_instr(*s))
+                    .map(|(p, s)| p.as_instr(*s))
                     .collect(),
             ),
         ))


### PR DESCRIPTION
There are only two warnings.

```
$ cargo clippy
warning: call to `.clone()` on a reference in this situation does nothing
   --> src/algorithm/invert.rs:468:36
    |
468 |                     .map(|(p, s)| p.clone().as_instr(*s))
    |                                    ^^^^^^^^ help: remove this redundant call
    |
    = note: the type `A` does not implement `Clone`, so calling `clone` on `&A` copies the reference, which
does not do anything and can be removed
    = note: `#[warn(noop_method_call)]` on by default

warning: call to `.clone()` on a reference in this situation does nothing
   --> src/algorithm/invert.rs:472:36
    |
472 |                     .map(|(p, s)| p.clone().as_instr(*s))
    |                                    ^^^^^^^^ help: remove this redundant call
    |
    = note: the type `B` does not implement `Clone`, so calling `clone` on `&B` copies the reference, which
does not do anything and can be removed

warning: `uiua` (lib) generated 2 warnings (run `cargo clippy --fix --lib -p uiua` to apply 2 suggestions)
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
```