### PR TITLE
add devShell to Nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,5 +24,13 @@
     in
       {
         packages.default = uiua-crate;
+        devShell = pkgs.mkShell {
+          inputsFrom = builtins.attrValues self.packages.${system};
+          nativeBuildInputs = [
+            pkgs.clippy
+            pkgs.rust-analyzer
+            pkgs.rustfmt
+          ];
+        };
       });
 }


### PR DESCRIPTION
This change allows Nix users to call `nix develop` to get into a reasonable Rust development environment that has clippy, rustfmt and rust-analyzer present.