### PR TITLE
Add formatter configuration option for disabling glyphs

### DIFF
--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -149,13 +149,10 @@ impl Primitive {
     }
     pub fn format(&self, f: &mut fmt::Formatter<'_>, options: &PrimitiveFormatOptions) -> fmt::Result {
         if let (Some(c), false) = (self.glyph(), options.disable_glyphs) {
-            println!("formatting {} as glyph", c);
             write!(f, "{}", c)
         } else if let Some(s) = self.ascii() {
-            println!("formatting {} as ascii", s);
             write!(f, "{}", s)
         } else if let Some(s) = self.name() {
-            println!("formatting {} as name", s);
             write!(f, "{}", s)
         } else {
             use Primitive::*;


### PR DESCRIPTION
# Context
Implementing this issue: https://github.com/uiua-lang/uiua/issues/60

Adds a `DisableGlyphs` flag to the `.fmt.ua` format configuration. If this is set to true, all glyphs will be converted back to their ascii representations. The formatter will also try to add spacing to make the names clearer when this is enabled.