### PR TITLE
site: fix font download fail when landing on /docs/<whatever>

### DIFF
--- a/site/src/editor.rs
+++ b/site/src/editor.rs
@@ -1221,7 +1221,7 @@ fn update_style() {
         .dyn_into::<HtmlStyleElement>()
         .unwrap();
     new_style.set_inner_text(&format!(
-        "@font-face {{ font-family: 'Code Font'; src: url('{font_name}.ttf') format('truetype'); }}\n\
+        "@font-face {{ font-family: 'Code Font'; src: url('/{font_name}.ttf') format('truetype'); }}\n\
         .sized-code {{ font-size: {font_size}; }} }}"
     ));
     document().head().unwrap().append_child(&new_style).unwrap();


### PR DESCRIPTION
Currently when you follow a link directly to any page under /docs/ (like https://www.uiua.org/docs/&httpsw) you will get an error that looks something like below in the browser console because the src url is relative to the current location. This tiny patch makes the url relative to the root which fixes the issue.

```
GET https://www.uiua.org/docs/DejaVuSansMono.ttf [HTTP/2 404  6ms]
downloadable font: download failed (font-family: "Code Font" style:normal weight:400 stretch:100 src index:0): status=2147746065 source: https://www.uiua.org/docs/DejaVuSansMono.ttf
```