### PR TITLE
Fix incorrect uiuism: 'Find the most common row in an array'

### DIFF
--- a/site/src/uiuisms.rs
+++ b/site/src/uiuisms.rs
@@ -170,7 +170,7 @@ uiuisms!(
     /// Filter by a dynamic predicate
     "▽!⊙. (=0◿2) ⇡10",
     /// Find the most common row in an array
-    r#"⊏⊢⍖⍘⊚⊛. "Hello World!""#,
+    r#"⊏⊃(⊢⍖⍘⊚⊛)⊝ "Hello World!""#,
     /// Convert a string to uppercase
     r#"-×32×≥@a,≤@z. "These are Words""#,
     /// Convert a string to lowercase


### PR DESCRIPTION
This PR proposes a fix for the uiuism called 'Find the most common row in an array'

Here's the original example:
```
⊏⊢⍖⍘⊚⊛. "Hello World!"
```
which correctly outputs `@l`

However, it doesn't work with many other strings.
The easiest example I could find was `"aabbb"` which should give `@b` but gives `@a`

I have not completely understood how inverse-where works yet, but I believe it works similarly to de-duplicate.
Knowing this, we could fix the example by de-duplicating the input also, and picking afterwards.
My proposed solution would be `⊏⊃(⊢⍖⍘⊚⊛)⊝`

This works on the basis that inverse-where and de-duplicate will use the first occurrence of rows as the order of output elements.