### PR TITLE
Add web backend for &runc and &runi

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -34,6 +34,17 @@
       }
     }(window.location))
   </script>
+  <script>
+    // This is for calling javascript with &runi
+    function run_js(f, args) {
+      try {
+        output = eval(f)
+        return [0, '' + output, null]
+      } catch (e) {
+        return [1, null, e.message]
+      }
+    }
+  </script>
   <!-- End Single Page Apps for GitHub Pages -->
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -127,6 +127,8 @@ sys_op! {
     ///
     /// Standard IO will be captured. The exit code, stdout, and stderr will each be pushed to the stack.
     ///
+    /// On the web, stdout is the return value of the expression 
+    /// 
     /// Expects either a string, a rank `2` character array, or a rank `1` array of [box] strings.
     (1(3), RunCapture, "&runc", "run command capture"),
     /// Change the current directory


### PR DESCRIPTION
Adds javascript eval as a command backend for run_command_capture and run_command_inherit.

Example usage
```
&runi {"alert" "'hello, world'"} # 0
⊙;;&runc "3+7" # 10
⊙;;&runc "Date.now()" # "1697515821857"
```