### PR TITLE
Fix `nix build` on Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
          buildInputs = nixpkgs.lib.optionals pkgs.stdenv.isDarwin [
            pkgs.iconv
            pkgs.darwin.apple_sdk.frameworks.CoreServices
+           pkgs.darwin.apple_sdk.frameworks.Foundation
         ];
       };
     in


### PR DESCRIPTION
Since a8b95634d589d7423ffd23a67a6cc24e7d267a36, `nix build` on Darwin emits the following errors:

```
$ nix build
error: builder for '/nix/store/1qjjkmmpzxky2zfb1nfg1j558wvk25fa-uiua-0.0.22.drv' failed with exit code 101;
       last 10 log lines:
       > ++ command cargo build --release --message-format json-render-diagnostics --locked
       >    Compiling uiua v0.0.22 (/private/tmp/nix-build-uiua-0.0.22.drv-0/source)
       > error: linking with `cc` failed: exit status: 1
...
       >   = note: ld: framework not found Foundation
       >           clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
```

This PR adds this extra dependency and seems to work.
