### PR TITLE
Fixes #199 double input when InputEvent isComposing.

### DIFF
--- a/site/src/editor/mod.rs
+++ b/site/src/editor/mod.rs
@@ -274,6 +274,10 @@ pub fn Editor<'a>(
     // Update the code when the textarea is changed
     let code_input = move |event: Event| {
         let event = event.dyn_into::<web_sys::InputEvent>().unwrap();
+        // to prevent double input of yet to be composed input events
+        if event.is_composing() {
+            return;
+        }
         let parent = code_element();
         let child: HtmlDivElement = event.target().unwrap().dyn_into().unwrap();
         if !parent.contains(Some(&child)) {


### PR DESCRIPTION
https://stackoverflow.com/a/76820833/5248014 somewhat based on this. 

Basically "Composition" is mechanism for complex characters to be inputted (Chinese characters, emojis, emoticons). So seems like we can just wait for composition to end by checking `isComposing` on `InputEvent`