### PR TITLE
Don't mutate file with `--to-stdout`

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -378,7 +378,11 @@ fn format_impl(
 /// Format Uiua code in a file at the given path
 ///
 /// This modifies the file
-pub fn format_file<P: AsRef<Path>>(path: P, config: &FormatConfig) -> UiuaResult<FormatOutput> {
+pub fn format_file<P: AsRef<Path>>(
+    path: P,
+    config: &FormatConfig,
+    dont_write: bool,
+) -> UiuaResult<FormatOutput> {
     let path = path.as_ref();
     let input =
         fs::read_to_string(path).map_err(|e| UiuaError::Load(path.to_path_buf(), e.into()))?;
@@ -386,8 +390,9 @@ pub fn format_file<P: AsRef<Path>>(path: P, config: &FormatConfig) -> UiuaResult
     if formatted.output == input {
         return Ok(formatted);
     }
-    let dont_write = env::var("UIUA_NO_FORMAT").is_ok_and(|val| val == "1");
-    if !dont_write {
+    let is_no_format_set = env::var("UIUA_NO_FORMAT").is_ok_and(|val| val == "1");
+    let should_write = !dont_write && !is_no_format_set;
+    if should_write {
         fs::write(path, &formatted.output)
             .map_err(|e| UiuaError::Format(path.to_path_buf(), e.into()))?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ fn run() -> UiuaResult {
                         formatter_options.format_config_source,
                         Some(&path),
                     )?;
-                    format_file(&path, &config)?;
+                    format_file(&path, &config, false)?;
                 }
                 let mode = mode.unwrap_or(RunMode::Normal);
                 #[cfg(feature = "audio")]
@@ -162,7 +162,7 @@ fn run() -> UiuaResult {
                 };
                 let config =
                     FormatConfig::from_source(formatter_options.format_config_source, Some(&path))?;
-                format_file(&path, &config)?;
+                format_file(&path, &config, false)?;
                 Uiua::with_native_sys()
                     .with_mode(RunMode::Test)
                     .print_diagnostics(true)
@@ -385,7 +385,7 @@ fn watch(
         const TRIES: u8 = 10;
         for i in 0..TRIES {
             let formatted = if let (Some(config), true) = (&config, format) {
-                format_file(path, config).map(|f| f.output)
+                format_file(path, config, false).map(|f| f.output)
             } else {
                 fs::read_to_string(path).map_err(|e| UiuaError::Load(path.to_path_buf(), e.into()))
             };
@@ -723,7 +723,7 @@ fn update(main: bool, check: bool) {
 }
 
 fn format_single_file(path: PathBuf, config: &FormatConfig, stdout: bool) -> Result<(), UiuaError> {
-    let output = format_file(path, config)?.output;
+    let output = format_file(path, config, stdout)?.output;
     if stdout {
         println!("{output}");
     }
@@ -733,7 +733,7 @@ fn format_single_file(path: PathBuf, config: &FormatConfig, stdout: bool) -> Res
 fn format_multi_files(config: &FormatConfig, stdout: bool) -> Result<(), UiuaError> {
     for path in uiua_files() {
         let path_as_string = path.to_string_lossy().into_owned();
-        let output = format_file(path, config)?.output;
+        let output = format_file(path, config, stdout)?.output;
         if stdout {
             println!("{path_as_string}");
             println!("{output}");


### PR DESCRIPTION
This stops the Uiua file being mutated if `--to-stdout` is used with `uiua fmt` as mentioned in #94