### PR TITLE
Update regex behavior

### DIFF
--- a/src/primitive/defs.rs
+++ b/src/primitive/defs.rs
@@ -1771,6 +1771,9 @@ primitive!(
     /// ex: regex "\\d+" "123"
     /// ex: P ← $"(\\d{_})"
     ///   : regex $"_-_-_"P3P3P4 "123-456-7890"
+    /// Regex patterns with optional captures can be used with [pack] or [fill].
+    /// ex: ⊐regex "a(b)?" "a ab"
+    /// ex: ⬚(□"")regex "a(b)?" "a ab"
     ///
     /// Uiua uses the [Rust regex crate](https://docs.rs/regex/latest/regex/) internally.
     (2, Regex, Misc, "regex"),

--- a/src/primitive/defs.rs
+++ b/src/primitive/defs.rs
@@ -1763,8 +1763,8 @@ primitive!(
     (1, Parse, Misc, "parse"),
     /// Match a regex pattern
     ///
-    /// Returns an list of [box]ed strings, with one string per matching group
-    /// ex: regex "h[io]" "hihaho"
+    /// Returns an array of [box]ed strings, with one string per matching group and one row per match
+    /// ex: regex "h([io])" "hihaho"
     /// ex: regex "hi" "dog"
     /// ex: regex "[a-z]+" "hello world"
     /// Escaped regex characters must be double-escaped.

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -809,18 +809,19 @@ fn regex(env: &mut Uiua) -> UiuaResult {
             cache.entry(pattern.clone()).or_insert(regex.clone())
         };
 
-        let mut matches = Value::builder(0);
-        regex.captures_iter(&target).for_each(|caps| {
+        let mut matches: Value =
+            Array::<Boxed>::new([0, regex.captures_len()].as_slice(), []).into();
+
+        for caps in regex.captures_iter(&target) {
             let row: EcoVec<Boxed> = caps
                 .iter()
                 .flatten()
                 .map(|m| Boxed(Value::from(m.as_str())))
                 .collect();
-            // This unwrap should be fine because fill context () is infalliable.
-            matches.add_row(row.into(), &()).unwrap();
-        });
+            matches.append(row.into(), env)?;
+        }
 
-        env.push(matches.finish());
+        env.push(matches);
         Ok(())
     })
 }

--- a/tests/units.ua
+++ b/tests/units.ua
@@ -103,8 +103,8 @@ ParseOrZero ← ⍣parse⋅⋅0
 ⍤⊃⋅∘≍ 27 -@\0 @\x1b
 ⍤⊃⋅∘≍ 4096 -@\0 @\u1000
 
-⍤⊃⋅∘≍ {"hello" "world"} regex "[a-z]+" "hello world"
-⍤⊃⋅∘≍ {} regex "[0-9]+" "hello world"
+⍤⊃⋅∘≍ [{"hello"} {"world"}] regex "[a-z]+" "hello world"
+⍤⊃⋅∘≍ ↯0_1 {} regex "[0-9]+" "hello world"
 ⍤⊃⋅∘≍ 1 ⍣(regex "([a-z]" "hello world")⋅1
 
 ⍤⊃⋅∘≍ 1 ⊗ 5 [1 5 5]


### PR DESCRIPTION
Update `regex` function to be more consistent. It will return a 2d array with one column for each capture group and one row for each match.