### PR TITLE
Add a function to get a ref to current stack

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -913,6 +913,10 @@ code:
         self.function_stack.clear();
         take(&mut self.stack)
     }
+    // Return a reference to the stack
+    pub fn get_stack(&self) -> &Vec<Value> {
+        &self.stack
+    }
     /// Pop a function from the function stack
     pub fn pop_function(&mut self) -> UiuaResult<Function> {
         self.function_stack.pop().ok_or_else(|| {

--- a/src/run.rs
+++ b/src/run.rs
@@ -914,7 +914,7 @@ code:
         take(&mut self.stack)
     }
     /// Return a reference to the stack
-    pub fn get_stack(&self) -> &Vec<Value> {
+    pub fn get_stack(&self) -> &[Value] {
         &self.stack
     }
     /// Pop a function from the function stack

--- a/src/run.rs
+++ b/src/run.rs
@@ -913,7 +913,7 @@ code:
         self.function_stack.clear();
         take(&mut self.stack)
     }
-    // Return a reference to the stack
+    /// Return a reference to the stack
     pub fn get_stack(&self) -> &Vec<Value> {
         &self.stack
     }


### PR DESCRIPTION
Useful when one needs a copy of  the stack, but still wants the interpreter to keep its state.