### PR TITLE
Prevent browsers from auto-inserting non-breaking-spaces in editor

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -439,7 +439,7 @@ input[type=number] {
     border: none;
     width: 100%;
     display: inline-block;
-    white-space: nowrap;
+    white-space: pre;
 }
 
 .line-numbers {


### PR DESCRIPTION
### The problem

Currently, if you:
- go to https://www.uiua.org/pad
- focus the editor
- hit the space bar
- click the `Run` button,
you get an error (``Error: Unknown identifier ` ` ``) because a non-breaking space character (`U+00A0`) was inserted instead of a plain (`U+0020`) ASCII space.

This not only happens on an empty pad but in fact, anytime you enter a space as the first character of a blank line.

This appear to be a behavior of browsers (I tested the latest versions of Safari, Chrome and Firefox) when editing `contenteditable` elements.

### The solution

I couldn't find a definitive documentation on this behaviour, but it disappears if the `contenteditable` element has the CSS attribute `white-space` set to `pre`. This doesn't seem to break anything else, but I may have missed some corner cases?
