### PR TITLE
Replace term_size with terminal_size, works on Windows 11 Arm64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
  "parking_lot",
  "signal-hook",
  "signal-hook-mio",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -712,7 +712,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1593,16 +1593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "kqueue"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,7 +1828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2769,7 +2759,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3094,7 +3084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3216,17 +3206,6 @@ dependencies = [
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "term_size"
-version = "1.0.0-beta1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a17d8699e154863becdf18e4fd28bd0be27ca72856f54daf75c00f2566898f"
-dependencies = [
- "kernel32-sys",
- "libc",
- "winapi 0.2.8",
 ]
 
 [[package]]
@@ -3594,7 +3573,7 @@ dependencies = [
  "serde_json",
  "serde_tuple",
  "serde_yaml",
- "term_size",
+ "terminal_size",
  "thread_local",
  "tinyvec",
  "tokio",
@@ -3842,12 +3821,6 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -3855,12 +3828,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -3874,7 +3841,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rayon = "1.8.0"
 regex = "1.10.2"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
-term_size = "1.0.0-beta1"
+terminal_size = "0.3.0"
 thread_local = "1"
 tinyvec = {version = "1", features = ["alloc", "serde"]}
 toml = "0.8.8"

--- a/src/grid_fmt.rs
+++ b/src/grid_fmt.rs
@@ -224,7 +224,7 @@ impl<T: GridFmt + ArrayValue> GridFmt for Array<T> {
             }
             *grid.last_mut().unwrap().last_mut().unwrap() = if boxed { '╜' } else { '╯' };
             // Handle really big grid
-            let max_width = term_size::dimensions().map_or(54, |(w, _)| w);
+            let max_width = terminal_size::terminal_size().map_or(54, |(w, _)| w.0 as usize);
             for row in grid.iter_mut() {
                 if row.len() > max_width {
                     let diff = row.len() - max_width;

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,7 +273,7 @@ fn run() -> UiuaResult {
                             })
                             .unwrap_or_else(|| "program".into());
                         let path = PathBuf::from(name).with_extension(env::consts::EXE_EXTENSION);
-                        #[allow(clippy::needless_borrow)]
+                        #[allow(clippy::needless_borrows_for_generic_args)]
                         if let Err(e) = fs::write(&path, bytes) {
                             eprintln!("Failed to write executable: {e}");
                             exit(1);
@@ -696,7 +696,7 @@ fn clear_watching() {
 fn clear_watching_with(s: &str, end: &str) {
     print!(
         "\r{}{}",
-        s.repeat(term_size::dimensions().map_or(10, |(w, _)| w)),
+        s.repeat(terminal_size::terminal_size().map_or(10, |(w, _)| w.0 as usize)),
         end,
     );
 }

--- a/src/sys_native.rs
+++ b/src/sys_native.rs
@@ -148,7 +148,9 @@ impl SysBackend for NativeSys {
         NATIVE_SYS.colored_errors.insert(message, colored);
     }
     fn term_size(&self) -> Result<(usize, usize), String> {
-        let (w, h) = term_size::dimensions().ok_or("Failed to get terminal size")?;
+        let (w, h) = terminal_size::terminal_size()
+            .ok_or("Failed to get terminal size")
+            .map(|(w, h)| (w.0 as usize, h.0 as usize))?;
         Ok((w, h.saturating_sub(1)))
     }
     #[cfg(feature = "raw_mode")]
@@ -254,7 +256,8 @@ impl SysBackend for NativeSys {
     }
     #[cfg(feature = "terminal_image")]
     fn show_image(&self, image: image::DynamicImage) -> Result<(), String> {
-        let (width, height) = if let Some((w, h)) = term_size::dimensions() {
+        let dim = terminal_size::terminal_size().map(|(w, h)| (w.0 as usize, h.0 as usize));
+        let (width, height) = if let Some((w, h)) = dim {
             let (tw, th) = (w as u32, h.saturating_sub(1) as u32);
             let (iw, ih) = (image.width(), image.height() / 2);
             let scaled_to_height = (iw * th / ih.max(1), th);


### PR DESCRIPTION
Replacing unmaintained term_size crate with terminal_size.
provides the added benefit of working on Windows 11 ARM64