### PR TITLE
Set editor autocapitalize attribute from "false" to "off"

### DIFF
--- a/site/src/editor/mod.rs
+++ b/site/src/editor/mod.rs
@@ -1207,7 +1207,7 @@ or \"embedpad\" to embed the editor"
                                 id={code_id}
                                 contenteditable="true"
                                 autocorrect="false"
-                                autocapitalize="false"
+                                autocapitalize="off"
                                 spellcheck="false"
                                 class="code-entry"
                                 style={format!("height: {code_height_em}em;")}


### PR DESCRIPTION
The set of [supported values](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize) for autocapitalize are none/off, sentences/on, words, or characters.

This will turn off autocapitalisation in the editor by default, making it easier to use the pad on e.g. mobile devices.

I first noticed this when using the pad on my phone and the text field would capitalise every new line, for example `Fork` rather than `fork`, and these aren't picked up as actual modifiers.