### PR TITLE
Add workflow for GitHub release builds

### DIFF
--- a/.github/scripts/get-release-notes.js
+++ b/.github/scripts/get-release-notes.js
@@ -1,0 +1,10 @@
+const { readFileSync } = require("fs");
+let md = readFileSync("changelog.md", "utf-8")
+if (md.includes(`## ${process.argv[2]}`)) {
+    let notes = md
+        .replaceAll(process.argv[2], "\0VER\0")
+        .match(/(?<=^|\n)## \0VER\0 .*?(?=\n## |$)/s)[0]
+        .replaceAll("\0VER\0", process.argv[2])
+        .trim()
+    console.log(notes)
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,15 +49,15 @@ jobs:
 
       # Install dependencies
       - if: matrix.target == 'armv7-unknown-linux-gnueabihf'
-        run: apt install -y gcc-arm-linux-gnueabihf
+        run: sudo apt-get install -y gcc-arm-linux-gnueabihf
       - if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: apt install -y gcc-aarch64-linux-gnu
+        run: sudo apt-get install -y gcc-aarch64-linux-gnu
       - if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: apt install -y musl-tools
+        run: sudo apt-get install -y musl-tools
       - if: matrix.target == 'armv7-unknown-linux-musleabihf'
-        run: apt install -y musl-tools
+        run: sudo apt-get install -y musl-tools
       - if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: apt install -y musl-tools
+        run: sudo apt-get install -y musl-tools
 
       # Build
       - name: Install target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
     steps:
       - name: Ensure tag matches cargo version
         run: |
-          CARGO_PKG_VERSION=$(cargo pkgid | cut -d# -f2)
-          if [ "${{ github.ref_name }}" != "$CARGO_PKG_VERSION" ]; then
-            echo "Tag ${{ github.ref_name }} does not match cargo version $CARGO_PKG_VERSION"
+          UIUA_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages | .[] | select(.name == "uiua") | .version')
+          if [ "${{ github.ref_name }}" != "$UIUA_VERSION" ]; then
+            echo "Tag ${{ github.ref_name }} does not match uiua version $UIUA_VERSION"
             exit 1
           fi
       - name: Prepare release notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,31 +9,33 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Create the release without assets, saves the upload url for later jobs to upload assets to
+  # Create the release without assets
   create_release:
     name: Create release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # - name: Ensure tag matches cargo version
-      #   run: |
-      #     CARGO_PKG_VERSION=$(cargo pkgid | cut -d# -f2)
-      #     if [ "${{ github.ref_name }}" != "$CARGO_PKG_VERSION" ]; then
-      #       echo "Tag ${{ github.ref_name }} does not match cargo version $CARGO_PKG_VERSION"
-      #       exit 1
-      #     fi
+      - name: Ensure tag matches cargo version
+        run: |
+          CARGO_PKG_VERSION=$(cargo pkgid | cut -d# -f2)
+          if [ "${{ github.ref_name }}" != "$CARGO_PKG_VERSION" ]; then
+            echo "Tag ${{ github.ref_name }} does not match cargo version $CARGO_PKG_VERSION"
+            exit 1
+          fi
       - name: Prepare release notes
         run: node .github/scripts/get-release-notes.js ${{ github.ref_name }} >> release_notes.md
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          # tag_name: ${{ github.ref_name }}
           body_path: ./release_notes.md
 
+  # Create the binaries and upload them as release assets
   create_binaries:
-    name: Create binaries
+    name: Create binary
     needs: create_release
     runs-on: ${{ matrix.os }}
+    env:
+      BINARY_EXT: ${{ matrix.os == 'windows-latest' && '.exe' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -57,12 +59,8 @@ jobs:
       - name: Build
         run: cargo build --bin uiua --release --target ${{ matrix.target }} --verbose
 
-      - if: matrix.os == 'windows-latest'
-        name: Zip (Windows)
-        run: 7z a -tzip uiua-bin-${{matrix.target}}.zip ./target/${{matrix.target}}/release/uiua.exe
-      - if: matrix.os != 'windows-latest'
-        name: Zip (Linux/MacOS)
-        run: 7z a -tzip uiua-bin-${{matrix.target}}.zip ./target/${{matrix.target}}/release/uiua
+      - name: Zip
+        run: 7z a -tzip uiua-bin-${{matrix.target}}.zip ./target/${{matrix.target}}/release/uiua${{env.BINARY_EXT}}
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
   create_release:
     name: Create release
     runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v3
       # - name: Ensure tag matches cargo version
@@ -27,7 +25,6 @@ jobs:
       - name: Prepare release notes
         run: node .github/scripts/get-release-notes.js ${{ github.ref_name }} >> release_notes.md
       - name: Create release
-        id: create_release
         uses: softprops/action-gh-release@v1
         with:
           # tag_name: ${{ github.ref_name }}
@@ -58,27 +55,17 @@ jobs:
       - name: Install target
         run: rustup target add ${{ matrix.target }}
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }} --verbose
+        run: cargo build --bin uiua --release --target ${{ matrix.target }} --verbose
 
       - if: matrix.os == 'windows-latest'
         name: Zip (Windows)
-        run: 7z a -tzip uiua-bin-${{matrix.target}}.zip ./target/release/uiua.exe
+        run: 7z a -tzip uiua-bin-${{matrix.target}}.zip ./target/${{matrix.target}}/release/uiua.exe
       - if: matrix.os != 'windows-latest'
         name: Zip (Linux/MacOS)
-        run: 7z a -tzip uiua-bin-${{matrix.target}}.zip ./target/release/uiua
+        run: 7z a -tzip uiua-bin-${{matrix.target}}.zip ./target/${{matrix.target}}/release/uiua
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v1
         with:
           files: |
             uiua-bin-${{matrix.target}}.zip
-
-      # - name: Upload release assets
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ needs.create_release.outputs.upload_url }}
-      #     asset_name: ${{ matrix.target }}
-      #     asset_path: ./target/uiua
-      #     asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,12 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
+      - uses: actions/checkout@v3
       - name: Ensure tag matches cargo version
         run: |
-          UIUA_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages | .[] | select(.name == "uiua") | .version')
-          if [ "${{ github.ref_name }}" != "$UIUA_VERSION" ]; then
-            echo "Tag ${{ github.ref_name }} does not match uiua version $UIUA_VERSION"
+          CARGO_PKG_VERSION=$(cargo pkgid | cut -d# -f2)
+          if [ "${{ github.ref_name }}" != "$CARGO_PKG_VERSION" ]; then
+            echo "Tag ${{ github.ref_name }} does not match cargo version $CARGO_PKG_VERSION"
             exit 1
           fi
       - name: Prepare release notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
       matrix:
         include:
           - { os: macos-latest,   target: x86_64-apple-darwin            }
-          - { os: macos-latest,   target: x86_64h-apple-darwin           }
           - { os: macos-latest,   target: aarch64-apple-darwin           }
           - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu       }
           - { os: ubuntu-latest,  target: armv7-unknown-linux-gnueabihf  }
@@ -48,6 +47,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # Install dependencies
+      - if: matrix.target == 'armv7-unknown-linux-gnueabihf'
+        run: apt install -y gcc-arm-linux-gnueabihf
+      - if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: apt install -y gcc-aarch64-linux-gnu
+      - if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: apt install -y musl-tools
+      - if: matrix.target == 'armv7-unknown-linux-musleabihf'
+        run: apt install -y musl-tools
+      - if: matrix.target == 'aarch64-unknown-linux-musl'
+        run: apt install -y musl-tools
+
+      # Build
       - name: Install target
         run: rustup target add ${{ matrix.target }}
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
           - { os: macos-latest,   target: x86_64-apple-darwin            }
           - { os: macos-latest,   target: aarch64-apple-darwin           }
           - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu       }
-          - { os: ubuntu-latest,  target: x86_64-unknown-linux-musl      }
           - { os: windows-latest, target: x86_64-pc-windows-msvc         }
           - { os: windows-latest, target: aarch64-pc-windows-msvc        }
     steps:
@@ -52,12 +51,14 @@ jobs:
       # Install dependencies
       - if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get install -y musl-tools
+      - if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install -y libasound2-dev libudev-dev
 
       # Build
       - name: Install target
         run: rustup target add ${{ matrix.target }}
       - name: Build
-        run: cargo build --bin uiua --release --target ${{ matrix.target }} --verbose
+        run: cargo build --bin uiua --features audio --release --target ${{ matrix.target }} --verbose
 
       - name: Zip
         run: 7z a -tzip uiua-bin-${{matrix.target}}.zip ./target/${{matrix.target}}/release/uiua${{env.BINARY_EXT}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install target
+        run: rustup target add ${{ matrix.target }}
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} --verbose
 
       # - name: Upload release assets
       #   uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Create the release without assets, saves the upload url for later jobs to upload assets to
+  create_release:
+    name: Create release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+  create_binaries:
+    name: Create binaries
+    needs: create_release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: macos-latest,   target: x86_64-apple-darwin            }
+          - { os: macos-latest,   target: x86_64h-apple-darwin           }
+          - { os: macos-latest,   target: aarch64-apple-darwin           }
+          - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu       }
+          - { os: ubuntu-latest,  target: armv7-unknown-linux-gnueabihf  }
+          - { os: ubuntu-latest,  target: aarch64-unknown-linux-gnu      }
+          - { os: ubuntu-latest,  target: x86_64-unknown-linux-musl      }
+          - { os: ubuntu-latest,  target: armv7-unknown-linux-musleabihf }
+          - { os: ubuntu-latest,  target: aarch64-unknown-linux-musl     }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc         }
+          - { os: windows-latest, target: aarch64-pc-windows-msvc        }
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      # - name: Upload release assets
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ needs.create_release.outputs.upload_url }}
+      #     asset_name: ${{ matrix.target }}
+      #     asset_path: ./target/uiua
+      #     asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,24 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
+      - name: Ensure tag matches cargo version
+        run: |
+          CARGO_PKG_VERSION=$(cargo pkgid | cut -d# -f2)
+          if [ "${{ github.ref_name }}" != "$CARGO_PKG_VERSION" ]; then
+            echo "Tag ${{ github.ref_name }} does not match cargo version $CARGO_PKG_VERSION"
+            exit 1
+          fi
+      - name: Prepare release notes
+        run: node .github/scripts/get-release-notes.js ${{ github.ref_name }} >> release_notes.md
       - name: Create release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
+          tag_name: ${{ github.ref_name }}
+          body_path: ./release_notes.md
+
   create_binaries:
     name: Create binaries
     needs: create_release
@@ -37,26 +45,14 @@ jobs:
           - { os: macos-latest,   target: x86_64-apple-darwin            }
           - { os: macos-latest,   target: aarch64-apple-darwin           }
           - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu       }
-          - { os: ubuntu-latest,  target: armv7-unknown-linux-gnueabihf  }
-          - { os: ubuntu-latest,  target: aarch64-unknown-linux-gnu      }
           - { os: ubuntu-latest,  target: x86_64-unknown-linux-musl      }
-          - { os: ubuntu-latest,  target: armv7-unknown-linux-musleabihf }
-          - { os: ubuntu-latest,  target: aarch64-unknown-linux-musl     }
           - { os: windows-latest, target: x86_64-pc-windows-msvc         }
           - { os: windows-latest, target: aarch64-pc-windows-msvc        }
     steps:
       - uses: actions/checkout@v3
 
       # Install dependencies
-      - if: matrix.target == 'armv7-unknown-linux-gnueabihf'
-        run: sudo apt-get install -y gcc-arm-linux-gnueabihf
-      - if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: sudo apt-get install -y gcc-aarch64-linux-gnu
       - if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: sudo apt-get install -y musl-tools
-      - if: matrix.target == 'armv7-unknown-linux-musleabihf'
-        run: sudo apt-get install -y musl-tools
-      - if: matrix.target == 'aarch64-unknown-linux-musl'
         run: sudo apt-get install -y musl-tools
 
       # Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,22 +17,20 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v3
-      - name: Ensure tag matches cargo version
-        run: |
-          CARGO_PKG_VERSION=$(cargo pkgid | cut -d# -f2)
-          if [ "${{ github.ref_name }}" != "$CARGO_PKG_VERSION" ]; then
-            echo "Tag ${{ github.ref_name }} does not match cargo version $CARGO_PKG_VERSION"
-            exit 1
-          fi
+      # - name: Ensure tag matches cargo version
+      #   run: |
+      #     CARGO_PKG_VERSION=$(cargo pkgid | cut -d# -f2)
+      #     if [ "${{ github.ref_name }}" != "$CARGO_PKG_VERSION" ]; then
+      #       echo "Tag ${{ github.ref_name }} does not match cargo version $CARGO_PKG_VERSION"
+      #       exit 1
+      #     fi
       - name: Prepare release notes
         run: node .github/scripts/get-release-notes.js ${{ github.ref_name }} >> release_notes.md
       - name: Create release
         id: create_release
         uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref_name }}
+          # tag_name: ${{ github.ref_name }}
           body_path: ./release_notes.md
 
   create_binaries:
@@ -61,6 +59,19 @@ jobs:
         run: rustup target add ${{ matrix.target }}
       - name: Build
         run: cargo build --release --target ${{ matrix.target }} --verbose
+
+      - if: matrix.os == 'windows-latest'
+        name: Zip (Windows)
+        run: 7z a -tzip uiua-bin-${{matrix.target}}.zip ./target/release/uiua.exe
+      - if: matrix.os != 'windows-latest'
+        name: Zip (Linux/MacOS)
+        run: 7z a -tzip uiua-bin-${{matrix.target}}.zip ./target/release/uiua
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            uiua-bin-${{matrix.target}}.zip
 
       # - name: Upload release assets
       #   uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Merry Christmas 🎄❄

This PR adds a workflow that does the following each time a versioned tag is created:
- Ensures the tag matches the uiua crate version
- Creates a release and pulls the respective `changelog.md` section as the description
- Builds and uploads binaries for multiple targets[^1] on the release

If you also wanted this to work for `cargo publish`, let me know the details of what goes into manually publishing a version.

[^1]: This PR adds builds for the following targets: `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`
