### PR TITLE
Allow virtual term input in raw mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,6 +2541,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
+name = "rawrrr"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfc983a8b7ed9d74314ec9f442b0c571d4adb2d59f9ced62b8e9ab9382fc0bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "rayon"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,7 +3565,6 @@ dependencies = [
  "color-backtrace",
  "colored",
  "crossbeam-channel",
- "crossterm",
  "ctrlc",
  "dashmap",
  "ecow",
@@ -3576,6 +3585,7 @@ dependencies = [
  "paste",
  "pathdiff",
  "rand",
+ "rawrrr",
  "rayon",
  "regex",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ toml = "0.8.8"
 unicode-segmentation = "1.10"
 
 # Native dependencies
-crossterm = {version = "0.27.0", optional = true}
+rawrrr = {version = "0.1.0", optional = true}
 httparse = {version = "1.8.0", optional = true}
 open = {version = "5", optional = true}
 rustls = {version = "0.22.1", optional = true, default-features = false, features = [
@@ -109,7 +109,7 @@ invoke = ["open"]
 lsp = ["tower-lsp", "tokio", "native_sys"]
 native_sys = []
 profile = ["serde_yaml", "indexmap"]
-raw_mode = ["crossterm", "native_sys"]
+raw_mode = ["rawrrr", "native_sys"]
 stand = ["native_sys"]
 terminal_image = ["viuer", "image"]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,10 @@ fn main() {
         }
     });
 
+    // This makes sure the terminal's original mode flags are remembered when disabling raw mode
+    #[cfg(feature = "raw_mode")]
+    rawrrr::save_term();
+
     if let Err(e) = run() {
         println!("{}", e.report());
         exit(1);
@@ -684,9 +688,7 @@ fn uiua_files() -> Vec<PathBuf> {
 const WATCHING: &str = "watching for changes...";
 fn print_watching() {
     #[cfg(feature = "raw_mode")]
-    {
-        _ = crossterm::terminal::disable_raw_mode();
-    }
+    rawrrr::disable_raw();
     eprint!("{}", WATCHING);
     stderr().flush().unwrap();
 }

--- a/src/sys_native.rs
+++ b/src/sys_native.rs
@@ -132,11 +132,7 @@ impl SysBackend for NativeSys {
 
             match b {
                 #[cfg(feature = "raw_mode")]
-                b'\r'
-                    if crossterm::terminal::is_raw_mode_enabled().map_err(|e| e.to_string())? =>
-                {
-                    break
-                }
+                b'\r' if rawrrr::is_raw() => break,
                 b'\r' => continue,
                 b'\n' | 3 => break,
                 b => buffer.push(b),
@@ -154,11 +150,11 @@ impl SysBackend for NativeSys {
     #[cfg(feature = "raw_mode")]
     fn set_raw_mode(&self, raw_mode: bool) -> Result<(), String> {
         if raw_mode {
-            crossterm::terminal::enable_raw_mode()
+            rawrrr::enable_raw()
         } else {
-            crossterm::terminal::disable_raw_mode()
+            rawrrr::disable_raw()
         }
-        .map_err(|e| e.to_string())
+        Ok(())
     }
     fn var(&self, name: &str) -> Option<String> {
         env::var(name).ok()


### PR DESCRIPTION
This PR adds support for virtual terminal input (e.g: `\x1b[B` for DownArrow) when reading from stdin in raw mode.
It does this by moving from crossterm to a [(smaller) crate](https://codeberg.org/twink/rawrrr) specifically for cross-platform tty raw mode. It works almost exactly like crossterm, but also uses the virtual terminal mode flag.

This also fixes a small bug with the uiua watch-runner where raw mode does not get disabled after the program exits, because `disable_raw_mode()` only worked after `enable_raw_mode()` was called at least once, which the main process never does, only the child process (even though they share the same stdio).

Motivation: I wanted to be handle arrow keys so I could make Tetris :^)