### PR TITLE
Allow `parse` to handle rational literals

### DIFF
--- a/src/algorithm/monadic.rs
+++ b/src/algorithm/monadic.rs
@@ -84,9 +84,14 @@ impl Value {
                 if s.contains('∞') {
                     s = s.replace('∞', &f64::INFINITY.to_string());
                 }
-                s.parse::<f64>()
-                    .map_err(|e| env.error(format!("Cannot parse into number: {}", e)))?
-                    .into()
+                match s.split_once('/') {
+                    Some((numer, denom)) => numer
+                        .parse::<f64>()
+                        .and_then(|n| denom.parse::<f64>().map(|d| n / d)),
+                    None => s.parse::<f64>(),
+                }
+                .map_err(|e| env.error(format!("Cannot parse into number: {}", e)))?
+                .into()
             }
             (Value::Box(arr), []) => {
                 let value = &arr.data[0].0;

--- a/src/primitive/defs.rs
+++ b/src/primitive/defs.rs
@@ -714,6 +714,7 @@ primitive!(
     ///
     /// ex: ⋕ "17"
     /// ex: ⋕ "3.1415926535897932"
+    /// ex: ⋕ "1/2"
     /// ex! ⋕ "dog"
     ///
     /// [parse] is semi-pervasive. It works on multidimensional arrays of characters or boxes.


### PR DESCRIPTION
e.g.
```
⋕ "1/2"
⋕ "π/4"
⋕ "3.14/2.718"
⋕ "-2/3"
⋕ "4/-5"
⋕ "-7/`6"
```