### PR TITLE
add numeric and letter check uiuisms

### DIFF
--- a/site/src/uiuisms.rs
+++ b/site/src/uiuisms.rs
@@ -138,7 +138,7 @@ uiuisms!(
     /// Check if character is numberic [0-9]
     "/=⊂⊃(≥@0)(≤@9)",
     /// Check if character is letter [a-zA-Z]
-    "≥3/+⊂⊂⊂⊃⊃⊃(≥@a)(≤@z)(≥@A)(≤@Z)",
+    "=3/+⊂⊂⊂⊃⊃⊃(≥@a)(≤@z)(≥@A)(≤@Z)",
     /// Check if an array is a palindrome
     r#"≍⇌. "racecar""#,
     /// Convert a number to a string

--- a/site/src/uiuisms.rs
+++ b/site/src/uiuisms.rs
@@ -135,6 +135,10 @@ uiuisms!(
     "↥⇌.⊞=.⇡ 5",
     /// Create a zero matrix of the same shape as another
     "≠. [1_1 2_2]",
+    /// Check if character is numberic [0-9]
+    "/=⊂⊃(≥@0)(≤@9)",
+    /// Check if character is letter [a-zA-Z]
+    "≥3/+⊂⊂⊂⊃⊃⊃(≥@a)(≤@z)(≥@A)(≤@Z)",
     /// Check if an array is a palindrome
     r#"≍⇌. "racecar""#,
     /// Convert a number to a string

--- a/site/src/uiuisms.rs
+++ b/site/src/uiuisms.rs
@@ -136,9 +136,9 @@ uiuisms!(
     /// Create a zero matrix of the same shape as another
     "≠. [1_1 2_2]",
     /// Check if character is numberic [0-9]
-    "/=⊂⊃(≥@0)(≤@9)",
+    "⊢×⊃(≥@0|≤@9)",
     /// Check if character is letter [a-zA-Z]
-    "=3/+⊂⊂⊂⊃⊃⊃(≥@a)(≤@z)(≥@A)(≤@Z)",
+    "⊢↥∩×⊃(≥@a|≤@z|≥@A|≤@Z)",
     /// Check if an array is a palindrome
     r#"≍⇌. "racecar""#,
     /// Convert a number to a string

--- a/site/src/uiuisms.rs
+++ b/site/src/uiuisms.rs
@@ -136,9 +136,9 @@ uiuisms!(
     /// Create a zero matrix of the same shape as another
     "≠. [1_1 2_2]",
     /// Check if character is numberic [0-9]
-    "⊢×⊃(≥@0|≤@9)",
+    "×⊃(≥@0|≤@9)",
     /// Check if character is letter [a-zA-Z]
-    "⊢↥∩×⊃(≥@a|≤@z|≥@A|≤@Z)",
+    "↥∩×⊃(≥@a|≤@z|≥@A|≤@Z)",
     /// Check if an array is a palindrome
     r#"≍⇌. "racecar""#,
     /// Convert a number to a string


### PR DESCRIPTION
Added uiuisms 
 * to check if character is numeric `[0-9]`. [Numberic demo](https://uiua.org/pad?src=0_8_0__SXNJbnQg4oaQIC894oqC4oqDKOKJpUAwKSjiiaRAOSkKCklzSW50ICIwIgpJc0ludCAiOSIKSXNJbnQgIjQiCklzSW50ICJBIgpJc0ludCAiYSIKSXNJbnQgImIiCklzSW50ICIpIgpJc0ludCAiXyIK)
 * to check if character is english letter `[a-zA-Z]`. [Letter check demo](https://uiua.org/pad?src=0_8_0__SXNMZXR0ZXIg4oaQID0zLyviioLiioLiioLiioPiioPiioMo4omlQEEpKOKJpEBaKSjiiaVAYSko4omkQHopCgpJc0xldHRlciAiMCIKSXNMZXR0ZXIgIjkiCklzTGV0dGVyICI0IgpJc0xldHRlciAiQSIKSXNMZXR0ZXIgImEiCklzTGV0dGVyICJiIgpJc0xldHRlciAiKSIKSXNMZXR0ZXIgIl8iCg==)

In numeric solution i used `/=` as a `AND` operator coz if char is number, the function will return [1,1], if its char code is smaller then `@0` it will return [0,1] and if its higher then `@9` it will be `[1,0]` so there's no way to get `[0,0]`

In letter solution we compare to 3 because for example letter `@b` will return [1 0 1 1] and we need to have `(1 and 0) or (1 and 1)`. So basically if we have 3 `1` then at least one condition is met, if we have 2 `1` neither condition is met. 

There is probably better solution without magic 