### PR TITLE
Get rand seed from OS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,6 +2969,7 @@ dependencies = [
  "comrak",
  "console_error_panic_hook",
  "enum-iterator",
+ "getrandom",
  "hound",
  "image",
  "instant",

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -20,6 +20,7 @@ uiua = {path = "..", default-features = false, features = ["bytes", "batteries"]
 urlencoding = "2"
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.40"
+getrandom = { version = "0.2", features = ["js"] }
 
 [dependencies.web-sys]
 features = [

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -944,7 +944,7 @@ fn regex(env: &mut Uiua) -> UiuaResult {
 /// Generate a random number, equivalent to [`Primitive::Rand`]
 pub fn random() -> f64 {
     thread_local! {
-        static RNG: RefCell<SmallRng> = RefCell::new(SmallRng::seed_from_u64(instant::now().to_bits()));
+        static RNG: RefCell<SmallRng> = RefCell::new(SmallRng::from_entropy());
     }
     RNG.with(|rng| rng.borrow_mut().gen::<f64>())
 }


### PR DESCRIPTION
Hi, using the current time as a random seed is not the best way to initialize random.

This PR makes `uiua` initialize random more sophisticatedly and should work in wasm too.