### PR TITLE
Add support for `‼` in custom modifier names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@ This version is not yet released. If you are reading this on the website, then t
 - Add the [`inventory ⍚`](https://uiua.org/docs/inventory) modifier, which iterates over the unboxed items of an array and re-boxes the results
   - This shortens a lot of box array code
 - Change [`content ◇`](https://uiua.org/docs/content)'s glyph to reflect its relationship with [`inventory ⍚`](https://uiua.org/docs/inventory). Code using `⊔` will continue to work and will be formatted as `◇`.
+- Custom modifiers with 2 or more arguments can now use `‼` at the end of their names. Modifier names with any combination of `!` and `‼` will be automatically parsed and formatted as `‼`s followed by one `!` if necessary.
 - `f` can now be used at the beginning of planet notation shorthand for [`fork ⊃`](https://uiua.org/docs/fork)
 - Inline functions are no longer required to be in a binding or modifier
   - This allows arbitrary code to be wrapped and marked with a signature

--- a/site/src/tutorial.rs
+++ b/site/src/tutorial.rs
@@ -1433,7 +1433,7 @@ ReduceRange!×4"/>
 OnRev! ← ≡⍜⇌^1
 OnRev!(↘1) ↯3_4⇡12
 OnRev!(⊂π) ↯3_4⇡12"/>
-        <p>"A custom modifier can take as many functions as you want."</p>
+        <p>"A custom modifier can take as many functions as you want. Modifiers with two or more function arguments will be formatted to use "<code>"‼"</code>"s as needed. Try running the following example to format it."</p>
         <Editor example="\
 F!!! ← ⊂/^2⊃^2^2
 F!!!+×⊂ [1 2 3][4 5 6]"/>

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -776,8 +776,7 @@ code:
             self.count_temp_functions(function.instrs(self), &mut HashSet::new());
         let name_marg_count = ident_modifier_args(name);
         if temp_function_count != name_marg_count {
-            let trimmed = name.trim_end_matches('!');
-            let this = format!("{}{}", trimmed, "!".repeat(temp_function_count));
+            let this = crate::parse::place_exclams(name, temp_function_count);
             self.add_error(
                 self.get_span(span),
                 format!(

--- a/src/format.rs
+++ b/src/format.rs
@@ -580,7 +580,8 @@ impl<'a> Formatter<'a> {
                     _ => self.prev_import_function = None,
                 }
 
-                self.output.push_str(&binding.name.value);
+                self.output
+                    .push_str(&crate::parse::canonicalize_exclams(&binding.name.value));
                 self.output.push_str(" ←");
                 if !binding.words.is_empty() || binding.signature.is_some() {
                     self.output.push(' ');

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -781,9 +781,17 @@ impl<'a> Lexer<'a> {
                         ident.push_str(c);
                     }
                     let mut exclam_count = 0;
-                    while self.next_char_exact("!") {
-                        ident.push('!');
-                        exclam_count += 1;
+                    while let Some((ch, count)) =
+                        if self.next_char_exact("!") {
+                            Some(('!', 1))
+                        } else if self.next_char_exact("‼") {
+                            Some(('‼', 2))
+                        } else {
+                            None
+                        }
+                    {
+                        ident.push(ch);
+                        exclam_count += count;
                     }
                     let ambiguous_ne = exclam_count == 1
                         && self.input_segments.get(self.loc.char_pos as usize) == Some(&"=");


### PR DESCRIPTION
Closes #398. Custom modifier names are now always parsed and formatted as their canonicalized form with ⌊n/2⌋ `‼` characters followed by one `!` if n is odd.