### PR TITLE
Use more idiomatic code in `classify` `group` examples

### DIFF
--- a/src/primitive/defs.rs
+++ b/src/primitive/defs.rs
@@ -1264,7 +1264,7 @@ primitive!(
     ///
     /// When combined with [classify], you can do things like counting the number of occurrences of each character in a string.
     /// ex: $ Count the characters in this string
-    ///   : ⊕{⊢:⧻.} ⊛.⊏⍏.
+    ///   : ⊕{⊃⊢⧻} ⊛.⊏⍏.
     ///
     /// [under][group] works if [group]'s function is [under]able.
     /// ex: ⍜⊕□≡⇌ ≠@ . $ These are some words

--- a/src/primitive/defs.rs
+++ b/src/primitive/defs.rs
@@ -673,7 +673,7 @@ primitive!(
     ///
     /// When combined with [group], you can do things like counting the number of occurrences of each character in a string.
     /// ex: $ Count the characters in this string
-    ///   : ⊕($"_ _"⊢:⧻.) ⊛.⊏⍏.
+    ///   : ⊕($"_ _"⊃⊢⧻) ⊛.⊏⍏.
     (1, Classify, MonadicArray, ("classify", '⊛')),
     /// Remove duplicate elements from an array
     ///


### PR DESCRIPTION
`fork F G` should be preferred over `F:G.`, no?