### PR TITLE
Fixed the description of `by` in the changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,7 @@ This version is not yet released. If you are reading this on the website, then t
   - `○` will continue to work and will be formatted as `∿`
 - [`map`](https://uiua.org/docs/map) arrays are now a less leaky abstraction. The keys are now stored as metadata on the values.
   - [`reverse ⇌`](https://uiua.org/docs/reverse), [`rotate ↻`](https://uiua.org/docs/rotate), [`take ↙`](https://uiua.org/docs/take), [`drop ↘`](https://uiua.org/docs/drop), and [`join ⊂`](https://uiua.org/docs/join) now work with [`map`](https://uiua.org/docs/map) arrays without corrupting them
-- Add the [`by ⊸`](https://uiua.org/docs/by) modifier, which duplicates the second value on the stack
+- Add the [`by ⊸`](https://uiua.org/docs/by) modifier, which duplicates a function's last argument before calling it
 - [`under ⍜`](https://uiua.org/docs/under) [`join ⊂`](https://uiua.org/docs/join) now works with arrays of the same rank as long as the row count does not change
 - [`un °`](https://uiua.org/docs/un) [`scan \\`](https://uiua.org/docs/scan) now works with [`equals =`](https://uiua.org/docs/equals) and [`not equals ≠`](https://www.uiua.org/docs/not%20equals)
 - [`group ⊕`](https://uiua.org/docs/group) can now take multidimensional index arrays


### PR DESCRIPTION
Didn't pay attention to the description when making the previous PR