### PR TITLE
 Fix `ctrlc` Dependency Version to Resolve Cargo Install Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ lockfree = {version = "0.5.1", optional = true}
 # Binary dependencies
 clap = {version = "4", optional = true, features = ["derive"]}
 color-backtrace = {version = "0.6.1", optional = true}
-ctrlc = {version = "3", optional = true}
+ctrlc = {version = "=3.4.2", optional = true}
 notify = {version = "6", optional = true}
 rustyline = {version = "13.0.0", optional = true}
 tokio = {version = "1", optional = true, features = ["io-std", "rt"]}


### PR DESCRIPTION
Encountered an error when running `cargo install uiua` related to the `ctrlc` crate. Investigation revealed that `ctrlc` was recently updated from 3.4.2 to 3.4.3. This update appears to introduce a breaking change or compatibility issue affecting Uiua installation.

**Fix**:
This pull request modifies `Cargo.toml` to specifically use `ctrlc` version 3.4.2, resolving the installation error:

```toml
ctrlc = {version = "=3.4.2", optional = true}
```

This change ensures that Uiua can be installed successfully using `cargo install uiua` and maintains stable functionality.