### PR TITLE
Fix "replace all" uiuism

### DIFF
--- a/site/src/uiuisms.rs
+++ b/site/src/uiuisms.rs
@@ -274,7 +274,7 @@ uiuisms!(
     /// Binomial coefficient
     "/×÷¬⟜+¯⇡ 3 5",
     /// Replace all of one element in a list with another
-    "⍜▽◌⊃=∘ [1 5 8 2] 5 3",
+    "⍜▽(↯△)⊃=∘ [1 5 8 5 2] 5 3",
     /// Boxed powerset
     "⍚▽⋯⇡ⁿ:2⧻⟜¤ [1 5 8 2]",
     /// Irrational number to n terms of continued fraction


### PR DESCRIPTION
* `under keep` can't undo if the destination length differs from the source's
  * I changed `pop` to `reshape shape`
* The uiuism didn't have more than one matching item to showcase the "all" part of the description
  * I added an extra copy of the needle to the haystack