### PR TITLE
Fix upscale uiuism for grayscale images

### DIFF
--- a/site/src/uiuisms.rs
+++ b/site/src/uiuisms.rs
@@ -214,7 +214,7 @@ uiuisms!(
     /// Trim whitespace
     r#"▽×⍜⇌∩\↥.≠@ . "  abc xyz   ""#,
     /// Upscale a 2d matrix or colored image
-    "30 [0_1 1_0.5]\n⍉◌⍥⟜(⍉▽▽⧻,)2\n30 [[0_0_1 0_1_0] [1_0_0 0_0_0]]\n⍉◌⍥⟜(⍉▽▽⧻,)2",
+    "30 [0_1 0.75_0.25]\n◌⍥⟜(⍉▽▽⧻,)2\n30 [[0_0_1 0_1_0] [1_0_0 0_0_0]]\n⍉◌⍥⟜(⍉▽▽⧻,)2",
     /// Linearly interpolate between two values
     "⍜-× 10 0 0.2\n⍜⊙-× 0.2 10 0",
     /// Set the value of an array at an index


### PR DESCRIPTION
The existing code would leave grayscale images/rank 2 arrays transposed. This was not caught because the example array is symmetrical about its main diagonal, and thus equivalent to its transpose. This PR fixes the uiuism and updates the example to not be symmetrical.