### PR TITLE
fix build on mac

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
         src = craneLib.cleanCargoSource (craneLib.path ./.);
          buildInputs = nixpkgs.lib.optionals pkgs.stdenv.isDarwin [
            pkgs.iconv
+           pkgs.darwin.apple_sdk.frameworks.AppKit
            pkgs.darwin.apple_sdk.frameworks.CoreServices
            pkgs.darwin.apple_sdk.frameworks.Foundation
         ];


### PR DESCRIPTION
Doing `cargo build --release` on my machine (Mac M1) failed with the following:

```
error: linking with `cc` failed: exit status: 1
  |
<<linker invocation command (very long)>>
  = note: ld: warning: directory not found for option '-L/Users/jonathan/Developer/github.com/uiua/target/debug/build/libffi-sys-f43b939538c33a1f/out/libffi-root/lib64'
          ld: framework not found AppKit
          clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
error: could not compile `uiua` (bin "uiua") due to 1 previous error
```

However with this patch it worked.