### PR TITLE
Add support for 20-byte return type structs

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -457,6 +457,7 @@ mod enabled {
                         8 => call_ret_struct!(8)?,
                         12 => call_ret_struct!(12)?,
                         16 => call_ret_struct!(16)?,
+                        20 => call_ret_struct!(20)?,
                         24 => call_ret_struct!(24)?,
                         32 => call_ret_struct!(32)?,
                         48 => call_ret_struct!(48)?,


### PR DESCRIPTION
Raylib textures are passed around by value as `{unsigned int; int; int; int; int}` structs, which happens to be a size that wasn't supported. Adding this line seemed to be all that was necessary!