### PR TITLE
Fix webkit combinator images

### DIFF
--- a/site/combinators/B.svg
+++ b/site/combinators/B.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/B1.svg
+++ b/site/combinators/B1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/C.svg
+++ b/site/combinators/C.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/D.svg
+++ b/site/combinators/D.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/D2.svg
+++ b/site/combinators/D2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/E.svg
+++ b/site/combinators/E.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/I.svg
+++ b/site/combinators/I.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/K.svg
+++ b/site/combinators/K.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/KI.svg
+++ b/site/combinators/KI.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/N.svg
+++ b/site/combinators/N.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/R.svg
+++ b/site/combinators/R.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/S.svg
+++ b/site/combinators/S.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/W.svg
+++ b/site/combinators/W.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/X.svg
+++ b/site/combinators/X.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/Ê.svg
+++ b/site/combinators/Ê.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/Δ.svg
+++ b/site/combinators/Δ.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/Σ.svg
+++ b/site/combinators/Σ.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/Φ.svg
+++ b/site/combinators/Φ.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/Φ1.svg
+++ b/site/combinators/Φ1.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/Ψ.svg
+++ b/site/combinators/Ψ.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/ε.svg
+++ b/site/combinators/ε.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/ν.svg
+++ b/site/combinators/ν.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/ρ.svg
+++ b/site/combinators/ρ.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/combinators/χ.svg
+++ b/site/combinators/χ.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="100%" height="100%">
     <style>
         .arg {
             fill: black;

--- a/site/src/other.rs
+++ b/site/src/other.rs
@@ -422,7 +422,7 @@ pub fn Combinators() -> impl IntoView {
                     <td>{ bird }</td>
                     <td>{ code }</td>
                     <td><Editor example={&ex} nonprogressive=true/></td>
-                    <td><img src={diagram} alt={bird} class="combinator-diagram"/></td>
+                    <td><object data={diagram} type="image/svg+xml" aria-label={bird} class="combinator-diagram"/></td>
                 </tr>
             }
         })


### PR DESCRIPTION
Webkit doesn't seem to allow CSS into `img` elements. This means Safari and all iPhone browsers have black-on-black letters with serifs in the combinator diagrams.

I use `object` elements to solve this. And to ensure the relative sizes stay the same, I use view boxes in the SVGs. This PR is based on fiddling in my browser, not running the site locally, so consider this un-tested and more of a proposal.