### PR TITLE
fix(editor): common macos shortcuts for next and previous respected

### DIFF
--- a/site/src/editor/mod.rs
+++ b/site/src/editor/mod.rs
@@ -286,7 +286,7 @@ pub fn Editor<'a>(
                 }
             }
             OutputItem::Svg(s) => view!(<div><img
-                    class="output-image" 
+                    class="output-image"
                     src={format!("data:image/svg+xml;utf8, {}", urlencoding::encode(&s))}/>
                 </div>)
             .into_view(),
@@ -688,7 +688,7 @@ pub fn Editor<'a>(
                 });
             }
             // Handle open delimiters
-            "(" | "[" | "{" => {
+            "(" | "[" | "{" if !event.meta_key() => {
                 // Surround the selected text with delimiters
                 let (open, close) = match key {
                     "\"" => ('"', '"'),
@@ -714,7 +714,7 @@ pub fn Editor<'a>(
                 });
             }
             // Handle close delimiters
-            ")" | "]" | "}" => {
+            ")" | "]" | "}" if !event.meta_key() => {
                 let (start, end) = get_code_cursor().unwrap();
                 let code = get_code();
                 let close = key.chars().next().unwrap();


### PR DESCRIPTION
# Problem:

On macOS, next and previous tab for documents/tabs within applications are bound to Cmd-Shift-[ and Cmd-Shift-]. Pressing these while in the editor changes tabs but invokes the delimiter insertion code leaving behind unwanted delimiters when coming back to the editor.

# Solution:

Only run the delimiter handling code if the `Cmd` button is not pressed.  This is detectable via use of the `meta` key in the browser.