### PR TITLE
Allow subscript numbers in identifiers

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -620,7 +620,7 @@ impl<'a> Formatter<'a> {
                 }
 
                 self.output
-                    .push_str(&crate::parse::canonicalize_exclams(&binding.name.value));
+                    .push_str(&crate::parse::canonicalize_ident(&binding.name.value));
                 self.output
                     .push_str(if binding.public { " ←" } else { " ↚" });
                 if binding.array_macro {


### PR DESCRIPTION
Subscripts will format from `__` followed by consecutive digits.
Identifiers are canonicalized during parsing so that `A__1` and `A₁` resolve to the same identifier (`A₁`) even when code is not formatted.