### PR TITLE
added a wildcard to the source cleaning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
         src = pkgs.lib.cleanSourceWith {
           src = ./.;
           # this is needed because else crane would filter out the included images from the build.
-          filter = path: type: ((path: _type: builtins.match ".*jpg$|.*png$" path != null) path type) || (craneLib.filterCargoSources path type);
+          filter = path: type: ((path: _type: builtins.match ".*$" path != null) path type) || (craneLib.filterCargoSources path type);
           name = "source";
         };
         nativeBuildInputs = [pkgs.pkg-config];


### PR DESCRIPTION
I should have done this in the first place
this is needed if files are included into the binary at compile time
the build failed because the font now is included with the include bytes macro
now all file types can pass the crane source filtering and cargo will manage what files to include