### PR TITLE
Add distinction between modulo and remainder to documentation

### DIFF
--- a/src/primitive/defs.rs
+++ b/src/primitive/defs.rs
@@ -739,6 +739,11 @@ primitive!(
     /// ex: ◿10 27
     /// ex: ◿5 [3 7 14]
     /// ex: ◿ [3 4 5] [10 10 10]
+    ///
+    /// The result is always non-negative:
+    /// ex: ◿ 4 ¯21
+    /// If you prefer the negative modulo instead of the remainder, you may use [under]:
+    /// ex: ⍜⊙⌵◿ 4 ¯21
     (2, Mod, DyadicPervasive, ("modulus", '◿')),
     /// Raise a value to a power
     ///


### PR DESCRIPTION
The modulo operator is implemented as what's commonly called "remainder", so this commit adds a line in the docs that explains this and an implementation of the "true" modulo.

I verified that the output is correct using [rust](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=c546bb1560c3536cf5190ead25a4afc3)'s implementation of `mod` and `rem_euclid` and [this pad link](https://uiua.org/pad?src=0_13_0-dev_2__UiDihpAg4pe_Ck0g4oaQIOKNnOKKmeKMteKXvwoKJE1QUCBNIDQgMjEKJE1OUCBNIDQgwq8yMQokTVBOIE0gwq80IDIxCiRNTk4gTSDCrzQgwq8yMQoiLS0tIgokUk5QIFIgNCAyMQokUk5QIFIgNCDCrzIxCiRSUE4gUiDCrzQgMjEKJFJOTiBSIMKvNCDCrzIxCg==)