### PR TITLE
Add direnv support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ uiua.tmLanguage.json
 
 # symlink created by `nix build`
 result
+.direnv


### PR DESCRIPTION
Makes it easier for IDEs and shells to use the flake automatically by triggering the devshell on `cd` (after explicitly allowing it the first time).