### PR TITLE
Maintain Nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ uiua.tmLanguage.json
 
 # symlink created by `nix build`
 result
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,12 @@
 {
   "nodes": {
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1712180168,
-        "narHash": "sha256-sYe00cK+kKnQlVo1wUIZ5rZl9x8/r3djShUqNgfjnM4=",
+        "lastModified": 1727235847,
+        "narHash": "sha256-MoEot8izwkfGm1h5ak8hS2bu59mLmKeevlP/OvFLCzM=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "06a9ff255c1681299a87191c2725d9d579f28b82",
+        "rev": "08f45b5a2e01cf34ca6081188c6d16aa35581b09",
         "type": "github"
       },
       "original": {
@@ -25,11 +20,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -40,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712163089,
-        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
+        "lastModified": 1726937504,
+        "narHash": "sha256-bvGoiQBvponpZh8ClUcmJ6QnsNKw0EMrCQJARK3bI1c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
+        "rev": "9357f4f23713673f310988025d9dc261c20e70c6",
         "type": "github"
       },
       "original": {
@@ -69,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725157860,
-        "narHash": "sha256-DhqyM7XJYKj+WAEaYwMtXaYX66tA+lOd31sd5QkxLDM=",
+        "lastModified": 1727231386,
+        "narHash": "sha256-XLloPtQHKk/Tdt8t8zIb+JhmunlH3YB9Jz8RTlQ3N/4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1fd72e343c6890f695243a37b367a1e3b90a49ee",
+        "rev": "b5f76c3b09a8194889f5328a480fbea1a9115518",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,8 @@
       devShell = pkgs.mkShell {
         inputsFrom = builtins.attrValues self.packages.${system};
         nativeBuildInputs = with pkgs; [
+          lld_18
+          trunk
           clippy
           rust-analyzer
           rustfmt

--- a/readme.md
+++ b/readme.md
@@ -37,16 +37,18 @@ This requires [Rust](https://www.rust-lang.org/tools/install) (>=1.75) to be ins
   ```
   cargo install --git https://github.com/uiua-lang/uiua uiua
   ```
-- If you use Nix or NixOS, you can clone this repo and do following:  
+- If you use Nix or NixOS, you can clone this repo and do following:
   ```
   nix develop    # to drop into a shell prompt with all the dependencies
-  cargo check    # to make sure you can compile/build latest version  
-  cargo build    # to build latest debug version of uiua  
-  cargo run repl # to get uiua repl  
+  cargo check    # to make sure you can compile/build latest version
+  cargo build    # to build latest debug version of uiua
+  cargo run repl # to get uiua repl
   ```
+  `nix develop` is not necessary if you have direnv active, in that case `direnv allow` will activate the flake devshell.
+  
   *Note:* If you encounter errors such as rustc or any other package
   version mismatch, it is most likely that flake.lock file needs to be
-  updated to pull in updated dependencies for nix shell.  
+  updated to pull in updated dependencies for nix shell.
 
 ## Language and Font Support
 


### PR DESCRIPTION
The flake.lock has a version of rust that was below the minimum needed for uiua.

Trunk and lld are also missing from the devshell, so they they've been added.

Finally, the readme is missing the direnv mention (which replaced `nix develop`), this PR adds it too.