### PR TITLE
added sixel encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,6 +1719,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "icy_sixel"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86858ae800284d596cfdefcb0ad435c3493c12f35367431bbe9b2b3858c1155b"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4090,6 +4096,7 @@ dependencies = [
  "hodaun",
  "hound",
  "httparse",
+ "icy_sixel",
  "image",
  "indexmap",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ uiua-nokhwa = {version = "0.10.5", optional = true, features = ["input-native"]}
 js-sys = {version = "0.3", optional = true}
 wasm-bindgen = {version = "0.2.92", optional = true}
 web-sys = {version = "0.3.60", optional = true}
+icy_sixel = {version = "0.1.2", optional = true}
 
 [features]
 audio = ["hodaun", "lockfree", "audio_encode"]
@@ -143,7 +144,7 @@ opt = [] # Enables some optimizations but increases binary size
 profile = ["serde_yaml"]
 raw_mode = ["rawrrr", "native_sys"]
 stand = ["native_sys"]
-terminal_image = ["viuer", "image"]
+terminal_image = ["viuer", "image", "icy_sixel"]
 tls = ["httparse", "rustls", "webpki-roots", "rustls-pemfile"]
 web = ["wasm-bindgen", "js-sys", "web-sys"]
 webcam = ["image", "uiua-nokhwa"]

--- a/src/sys_native.rs
+++ b/src/sys_native.rs
@@ -584,18 +584,35 @@ impl SysBackend for NativeSys {
         } else {
             (None, None)
         };
-        viuer::print(
-            &image,
-            &viuer::Config {
-                width,
-                height,
-                absolute_offset: false,
-                transparent: true,
-                ..Default::default()
-            },
-        )
-        .map(drop)
-        .map_err(|e| format!("Failed to show image: {e}"))
+        if env!("TERM").contains("sixel") {
+            let img_rgba8 = image.to_rgba8();
+            let sixel = icy_sixel::sixel_string(
+                image.to_rgba8().as_raw(),
+                img_rgba8.width() as i32,
+                img_rgba8.height() as i32,
+                icy_sixel::PixelFormat::RGBA8888,
+                icy_sixel::DiffusionMethod::Stucki,
+                icy_sixel::MethodForLargest::Auto,
+                icy_sixel::MethodForRep::Auto,
+                icy_sixel::Quality::HIGH,
+            );
+            let s = sixel.map_err(|e| e.to_string())?;
+            print!("{s}");
+            Ok(())
+        } else {
+            viuer::print(
+                &image,
+                &viuer::Config {
+                    width,
+                    height,
+                    absolute_offset: false,
+                    transparent: true,
+                    ..Default::default()
+                },
+            )
+            .map(drop)
+            .map_err(|e| format!("Failed to show image: {e}"))
+        }
     }
     #[cfg(all(feature = "gif", feature = "invoke"))]
     fn show_gif(&self, gif_bytes: Vec<u8>, _: Option<&str>) -> Result<(), String> {

--- a/src/sys_native.rs
+++ b/src/sys_native.rs
@@ -584,7 +584,10 @@ impl SysBackend for NativeSys {
         } else {
             (None, None)
         };
-        if env!("TERM").contains("sixel") {
+        if std::env::var("TERM")
+            .unwrap_or("".to_owned())
+            .contains("sixel")
+        {
             let img_rgba8 = image.to_rgba8();
             let sixel = icy_sixel::sixel_string(
                 image.to_rgba8().as_raw(),


### PR DESCRIPTION
This is in regards to this https://github.com/uiua-lang/uiua/issues/38 issue, as suggested i used icy_sixel

It encodes to sixel if it finds `sixel` in the `TERM` environment variable. That sadly isn't always the case but I couldn't find another way to detect if a terminal supports sixel. And I wanted to prevent false-positive sixel output because if you don't know what it is this string of random chars is rather confusing. So there will be quite a few false-negatives but there is still the half block fallback from `viuer`

I hope this is what y'all had in mind and I am looking forward to your criticism