### PR TITLE
adding a sixel enabeling env var 

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -370,7 +370,7 @@ sys_op! {
     /// How the image is shown depends on the system backend.
     ///
     /// In the default backend, the image is shown in the terminal. Here you can make it use sixel
-    /// by setting the `UIUA_ENABLE_SIXEL` environment variable to `1`. Else it will try to use the
+    /// by setting the `UIUA_ENABLE_SIXEL` environment variable to `1`. Otherwise it will try to use the
     /// `kitty` or `iTerm` image protocols and fall back to half-block image printing.
     /// On the web, the image is shown in the output area.
     ///

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -369,7 +369,9 @@ sys_op! {
     ///
     /// How the image is shown depends on the system backend.
     ///
-    /// In the default backend, the image is shown in the terminal.
+    /// In the default backend, the image is shown in the terminal. Here you can make it use sixel
+    /// by setting the `UIUA_ENABLE_SIXEL` environment variable to `1`. Else it will try to use the
+    /// `kitty` or `iTerm` image protocols and fall back to half-block image printing.
     /// On the web, the image is shown in the output area.
     ///
     /// The image must be a rank 2 or 3 numeric array.

--- a/src/sys_native.rs
+++ b/src/sys_native.rs
@@ -587,6 +587,7 @@ impl SysBackend for NativeSys {
         if std::env::var("TERM")
             .unwrap_or("".to_owned())
             .contains("sixel")
+            || std::env::var("UIUA_ENABLE_SIXEL") == Ok(String::from("1"))
         {
             let img_rgba8 = image.to_rgba8();
             let sixel = icy_sixel::sixel_string(

--- a/src/sys_native.rs
+++ b/src/sys_native.rs
@@ -587,7 +587,7 @@ impl SysBackend for NativeSys {
         if std::env::var("TERM")
             .unwrap_or("".to_owned())
             .contains("sixel")
-            || std::env::var("UIUA_ENABLE_SIXEL") == Ok(String::from("1"))
+            || std::env::var("UIUA_ENABLE_SIXEL").is_ok_and(|s| s == "1")
         {
             let img_rgba8 = image.to_rgba8();
             let sixel = icy_sixel::sixel_string(


### PR DESCRIPTION
sorry for making yet another PR regarding the same topic and including only a small change

but here i addressed some points made in https://github.com/uiua-lang/uiua/issues/38 issue

I added the option to force-enable sixel via an environment variable and documented it in the docs for `&ims` in I way i thought was fitting

hope this helped