### PR TITLE
refactor(flake): clean up the flake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,10 @@ tls = ["httparse", "rustls", "webpki-roots", "rustls-pemfile"]
 web = ["wasm-bindgen", "js-sys", "web-sys"]
 webcam = ["image", "uiua-nokhwa"]
 xlsx = ["calamine", "simple_excel_writer"]
+# Use system static libraries instead of building them
+system = [
+  "libffi?/system"
+]
 
 [[bin]]
 name = "uiua"

--- a/flake.lock
+++ b/flake.lock
@@ -15,21 +15,23 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -52,44 +54,8 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1727231386,
-        "narHash": "sha256-XLloPtQHKk/Tdt8t8zIb+JhmunlH3YB9Jz8RTlQ3N/4=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "b5f76c3b09a8194889f5328a480fbea1a9115518",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,80 +3,45 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
     };
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-    };
+    crane.url = "github:ipetkov/crane";
   };
-  outputs = {
-    self,
-    nixpkgs,
-    flake-utils,
-    crane,
-    rust-overlay,
-  }:
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [(import rust-overlay)];
-      };
-      toolchain = pkgs.rust-bin.stable.latest.default;
-      craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
-      uiua-crate = craneLib.buildPackage rec {
-        src = pkgs.lib.cleanSourceWith {
-          src = ./.;
-          # this is needed because else crane would filter out the included images from the build.
-          filter = path: type: ((path: _type: builtins.match ".*$" path != null) path type) || (craneLib.filterCargoSources path type);
-          name = "source";
+  outputs =
+    {
+      nixpkgs,
+      flake-parts,
+      crane,
+      ...
+    }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = nixpkgs.lib.platforms.all;
+      perSystem =
+        {
+          self',
+          pkgs,
+          ...
+        }:
+        let
+          craneLib = crane.mkLib pkgs;
+        in
+        {
+          packages.default = pkgs.callPackage ./package.nix { inherit craneLib; };
+          devShells.default = pkgs.mkShell {
+            inputsFrom = builtins.attrValues self'.packages;
+            packages = with pkgs; [
+              lld_18
+              trunk
+              clippy
+              rust-analyzer
+              rustfmt
+              cargo
+              rustc
+              libffi
+            ];
+          };
         };
-        nativeBuildInputs = [pkgs.pkg-config];
-        buildInputs =
-          nixpkgs.lib.optionals pkgs.stdenv.isDarwin [
-            pkgs.iconv
-            pkgs.libffi
-            pkgs.darwin.apple_sdk.frameworks.AppKit
-            pkgs.darwin.apple_sdk.frameworks.CoreServices
-            pkgs.darwin.apple_sdk.frameworks.Foundation
-          ]
-          ++ [
-            pkgs.libffi
-          ];
-          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
-          # I am sorry for this abomination but this is needed so that libffi is compiled with the "system" feature
-          # else it would try to build libffi-sys as a dependency, which fails with the nix build system
-          # so nix users will pull libffi (sys) from nixpkgs and not build "libffi-sys" and non-nix users will not have to include the libffi system lib
-          # sadly this does not work with git patches because of cranes source handeling
-        preConfigureHooks = with pkgs; ''
-          text_to_insert='features = ["system"]'
-          # this is the case for building the uiua dependencies
-          # it matches on the "[dependencies.libffi]" line and adds the above text below that
-          sed -i "/dependencies.libffi/ a $text_to_insert" "Cargo.toml"
-          replacement_text='libffi = {version = "3", optional = true, features = ["system"]}'
-          # this is the case when building the uiua package
-          # it replaces the dependency declaration with one that enables the "system" feature
-          sed -i "/libffi = /c $replacement_text" "Cargo.toml"
-        '';
-      };
-    in {
-      packages.default = uiua-crate;
-      devShell = pkgs.mkShell {
-        inputsFrom = builtins.attrValues self.packages.${system};
-        nativeBuildInputs = with pkgs; [
-          lld_18
-          trunk
-          clippy
-          rust-analyzer
-          rustfmt
-          cargo
-          rustc
-          libffi
-        ];
-      };
-    });
+    };
 }

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,48 @@
+{
+  craneLib,
+  stdenv,
+  lib,
+  pkg-config,
+  libffi,
+  libiconv,
+  darwin,
+  doCheck ? true,
+}:
+let
+  commonArgs = {
+    src = lib.fileset.toSource {
+      root = ./.;
+      fileset = lib.fileset.unions (
+        [
+          (lib.fileset.fromSource (craneLib.cleanCargoSource ./.))
+          ./src/primitive/assets
+          ./site/Uiua386.ttf
+        ]
+        ++ lib.optionals doCheck [
+          ./site/favicon.ico
+          ./tests
+        ]
+      );
+    };
+    strictDeps = true;
+    cargoExtraArgs = "--features system";
+    inherit doCheck;
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs =
+      [ libffi ]
+      ++ lib.optionals stdenv.isDarwin (
+        with darwin.apple_sdk.frameworks;
+        [
+          libiconv
+          AppKit
+          Foundation
+        ]
+      );
+  };
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+  totalArgs = commonArgs // {
+    inherit cargoArtifacts;
+    cargoTestExtraArgs = "-- --skip format::generate_format_cfg_docs";
+  };
+in
+craneLib.buildPackage totalArgs


### PR DESCRIPTION
1. Add a cargo feature named `system` which causes dependencies to use system versions of static libraries instead of compiling their own, which is particularly important to Nix (previously the Nix derivation would patch `Cargo.toml` to enable the corresponding `libffi` feature).
2. Separate the package derivation from the flake itself.
3. Properly clean source for the derivation, so changing files that are not used for building would not make Nix think everything needs to be rebuilt.
4. Remove `rust-overlay` dependency. It is great, but unnecessary here, as Uiua does not need bleeding-edge toolchain versions or specific components and targets. It would make sense to use it if the website was built with Nix as well.
5. Use `flake-parts` instead of `flake-utils` as it doesn't have design flaws `flake-utils` has and fits Nix better.
6. Remove input overrides from `crane` as `crane` doesn't have any inputs anymore.
7. Generally clean up Nix code, as there was some suspicious things like calling an ad hoc constructed function (`(path: _type: ...) path type`).
8. Build dependencies separately from the main derivation to improve incremental compilation.

This also revealed a couple of suspicious things like the tests depending on the website favicon and one of the tests actually trying to write some file, so I decided to disable it when building with Nix (`format::generate_format_cfg_docs`).