### PR TITLE
Move the pad to it's own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3536,6 +3536,7 @@ dependencies = [
  "serde",
  "serde_json",
  "uiua",
+ "uiua-editor",
  "unicode-segmentation",
  "urlencoding",
  "wasm-bindgen",
@@ -4142,6 +4143,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "uiua-editor"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.0",
+ "console_error_panic_hook",
+ "hound",
+ "image",
+ "js-sys",
+ "leptos",
+ "leptos_router",
+ "log",
+ "uiua",
+ "unicode-segmentation",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-logger",
+ "web-sys",
+]
+
+[[package]]
 name = "uiua-nokhwa"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4458,6 +4480,17 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "wasm-logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074649a66bb306c8f2068c9016395fa65d8e08d2affcbf95acf3c24c3ab19718"
+dependencies = [
+ "log",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ system = ["libffi?/system"]
 name = "uiua"
 
 [workspace]
-members = ["site", "tests_ffi"]
+members = ["site", "tests_ffi", "pad/editor"]
 
 [profile.dev]
 incremental = true

--- a/pad/editor/Cargo.toml
+++ b/pad/editor/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "uiua-editor"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+leptos = { version = "0.6.10", features = ["csr"] }
+js-sys = "0.3.69"
+web-sys = { version = "0.3.70", features = [
+    "Window",
+    "CustomElementRegistry",
+    "CssStyleDeclaration",
+    "DomRect",
+    "Storage",
+    "HtmlAudioElement",
+    "HtmlBrElement",
+    "Selection",
+    "Node",
+    "Clipboard",
+    "ClipboardEvent",
+    "DataTransfer",
+    "Navigator",
+    "Permissions",
+    "ScrollIntoViewOptions",
+    "ScrollBehavior",
+    "ScrollLogicalPosition",
+    "StorageManager",
+    "FileReader",
+    "EventInit",
+    "DataTransfer",
+    "File",
+    "FileList",
+    "ResizeObserver",
+    "ResizeObserverEntry",
+    "Performance",
+] }
+base64 = "0.22.0"
+leptos_router = {version = "0.6.11", features = ["csr"]}
+uiua = {path = "../..", default-features = false, features = ["batteries", "web"]}
+image = "0.24.9"
+unicode-segmentation = "1.10"
+urlencoding = "2"
+wasm-bindgen = "0.2.93"
+wasm-bindgen-futures = "0.4.43"
+hound = "3.5.1"
+
+# logging
+log = "0.4"
+wasm-logger = "0.2.0"
+console_error_panic_hook = "0.1.5"

--- a/pad/editor/src/backend.rs
+++ b/pad/editor/src/backend.rs
@@ -10,12 +10,10 @@ use std::{
 use crate::{get_ast_time, START_TIME};
 use js_sys::Date;
 use leptos::*;
-use uiua::{
-    now, GitTarget, Handle, Report, SysBackend, EXAMPLE_TXT, EXAMPLE_UA
-};
+use uiua::{now, GitTarget, Handle, Report, SysBackend, EXAMPLE_TXT, EXAMPLE_UA};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{Request, RequestInit, RequestMode, Response, HtmlAudioElement};
+use web_sys::{HtmlAudioElement, Request, RequestInit, RequestMode, Response};
 
 pub struct WebBackend {
     pub stdout: Mutex<Vec<OutputItem>>,

--- a/pad/editor/src/backend.rs
+++ b/pad/editor/src/backend.rs
@@ -7,13 +7,15 @@ use std::{
     sync::Mutex,
 };
 
-use crate::{editor::get_ast_time, weewuh, START_TIME};
+use crate::{get_ast_time, START_TIME};
 use js_sys::Date;
 use leptos::*;
-use uiua::{now, GitTarget, Handle, Report, SysBackend, EXAMPLE_TXT, EXAMPLE_UA};
+use uiua::{
+    now, GitTarget, Handle, Report, SysBackend, EXAMPLE_TXT, EXAMPLE_UA
+};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{Request, RequestInit, RequestMode, Response};
+use web_sys::{Request, RequestInit, RequestMode, Response, HtmlAudioElement};
 
 pub struct WebBackend {
     pub stdout: Mutex<Vec<OutputItem>>,
@@ -38,6 +40,18 @@ thread_local! {
         .map(|(path, content)| (PathBuf::from(path), content.as_bytes().to_vec()))
         .into(),
     );
+}
+
+fn weewuh() {
+    let i = (now() % 1.0 * 100.0) as u32;
+    let src = match i {
+        0 => "/assets/ooh-ee-ooh-ah.mp3",
+        1..=4 => "/assets/wee-wah.mp3",
+        _ => "/assets/wee-wuh.mp3",
+    };
+    if let Ok(audio) = HtmlAudioElement::new_with_src(src) {
+        _ = audio.play();
+    }
 }
 
 pub fn drop_file(path: PathBuf, contents: Vec<u8>) {

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod utils;
 pub mod backend;
+pub mod utils;
 
 use std::{cell::Cell, iter::repeat, mem::take, path::PathBuf, time::Duration};
 
@@ -14,9 +14,9 @@ use leptos::{
 use leptos_router::{use_navigate, BrowserIntegration, History, LocationChange, NavigateOptions};
 use uiua::{
     format::{format_str, FormatConfig},
-    is_ident_char, lex, now, seed_random, Primitive, SysOp, Token,
-    PrimClass, Signature,
+    is_ident_char, lex,
     lsp::{BindingDocs, BindingDocsKind},
+    now, seed_random, PrimClass, Primitive, Signature, SysOp, Token,
 };
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use web_sys::{
@@ -25,11 +25,11 @@ use web_sys::{
 };
 
 use utils::*;
-use utils::{get_ast_time, element};
+use utils::{element, get_ast_time};
 
+use backend::{drop_file, OutputItem};
 use js_sys::Date;
 use std::sync::OnceLock;
-use backend::{OutputItem, drop_file};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EditorMode {
@@ -72,7 +72,7 @@ pub fn Editor<'a>(
     // Initialize all the examples
     let examples = match mode {
         EditorMode::Example if !nonprogressive => progressive_strings(example),
-        EditorMode::Showcase => examples.unwrap_or(vec![]),
+        EditorMode::Showcase => examples.unwrap_or_default(),
         _ => vec![example.into()],
     };
     let code_max_lines = if let EditorMode::Pad = mode {

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -1,4 +1,5 @@
-mod utils;
+pub mod utils;
+pub mod backend;
 
 use std::{cell::Cell, iter::repeat, mem::take, path::PathBuf, time::Duration};
 
@@ -9,10 +10,13 @@ use leptos::{
     ev::{keydown, keyup},
     *,
 };
+
 use leptos_router::{use_navigate, BrowserIntegration, History, LocationChange, NavigateOptions};
 use uiua::{
     format::{format_str, FormatConfig},
     is_ident_char, lex, now, seed_random, Primitive, SysOp, Token,
+    PrimClass, Signature,
+    lsp::{BindingDocs, BindingDocsKind},
 };
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use web_sys::{
@@ -20,27 +24,26 @@ use web_sys::{
     HtmlSelectElement, HtmlTextAreaElement, MouseEvent,
 };
 
-use crate::{
-    backend::{drop_file, OutputItem},
-    element,
-    examples::EXAMPLES,
-    get_element, prim_class, Prim,
-};
-
 use utils::*;
-pub use utils::{get_ast_time, Challenge};
+use utils::{get_ast_time, element};
+
+use js_sys::Date;
+use std::sync::OnceLock;
+use backend::{OutputItem, drop_file};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EditorMode {
     #[default]
     Example,
-    Front,
+    Showcase,
     Pad,
 }
 
 thread_local! {
     static ID: Cell<u64> = const { Cell::new(0) };
 }
+
+static START_TIME: OnceLock<f64> = OnceLock::new();
 
 /// An editor for Uiua code
 #[component]
@@ -51,7 +54,10 @@ pub fn Editor<'a>(
     #[prop(optional)] no_run: bool,
     #[prop(optional)] challenge: Option<ChallengeDef>,
     #[prop(optional)] nonprogressive: bool,
+    #[prop(optional)] examples: Option<Vec<String>>,
 ) -> impl IntoView {
+    START_TIME.get_or_init(|| Date::now() / 1000.0);
+
     let no_run = no_run
         || mode == EditorMode::Pad && !get_autorun()
         || ["&sl", "&httpsw", "send", "recv", "&ffi", "&clip"]
@@ -66,7 +72,7 @@ pub fn Editor<'a>(
     // Initialize all the examples
     let examples = match mode {
         EditorMode::Example if !nonprogressive => progressive_strings(example),
-        EditorMode::Front => EXAMPLES.iter().map(ToString::to_string).collect(),
+        EditorMode::Showcase => examples.unwrap_or(vec![]),
         _ => vec![example.into()],
     };
     let code_max_lines = if let EditorMode::Pad = mode {
@@ -1158,7 +1164,7 @@ pub fn Editor<'a>(
         if desc.chars().count() > 30 {
             desc = desc.chars().take(29).chain(['…']).collect();
         }
-        let text = format!("{:max_name_len$} - {desc}", prim.name()).replace(' ', " ");
+        let text = format!("{:max_name_len$} - {desc}", prim.name()).replace(' ', " ");
         options.push(view!(<option
             class=class
             value={prim.name()}>
@@ -1187,7 +1193,7 @@ pub fn Editor<'a>(
     // Select a class for the editor and code area
     let editor_class = match mode {
         EditorMode::Example => "small-editor",
-        EditorMode::Front | EditorMode::Pad => "medium-editor",
+        EditorMode::Showcase | EditorMode::Pad => "medium-editor",
     };
 
     // Hide the example arrows if there is only one example
@@ -1200,7 +1206,7 @@ pub fn Editor<'a>(
     // Show or hide the glyph buttons
     let (show_glyphs, set_show_glyphs) = create_signal(match mode {
         EditorMode::Example => false,
-        EditorMode::Front | EditorMode::Pad => true,
+        EditorMode::Showcase | EditorMode::Pad => true,
     });
 
     // Glyphs toggle button
@@ -1712,6 +1718,142 @@ pub fn Editor<'a>(
                 { help.iter().map(|s| view!(<p>{s}</p>)).collect::<Vec<_>>() }
             </div>
         </div>
+    }
+}
+
+#[component]
+pub fn Prim(
+    prim: Primitive,
+    #[prop(optional)] glyph_only: bool,
+    #[prop(optional)] hide_docs: bool,
+) -> impl IntoView {
+    let symbol_class = format!("prim-glyph {}", prim_class(prim));
+    let symbol = prim.to_string();
+    let name = if !glyph_only && symbol != prim.name() {
+        format!(" {}", prim.name())
+    } else {
+        "".to_string()
+    };
+    let href = format!("/docs/{}", prim.name());
+    let mut title = String::new();
+    if let Some(ascii) = prim.ascii() {
+        title.push_str(&format!("({})", ascii));
+    }
+    if prim.glyph().is_some() && glyph_only {
+        if !title.is_empty() {
+            title.push(' ');
+        }
+        title.push_str(prim.name());
+    }
+    if let Primitive::Sys(op) = prim {
+        title.push_str(op.long_name());
+        title.push(':');
+        title.push('\n');
+    }
+    if !hide_docs {
+        let doc = prim.doc();
+        if glyph_only && !title.is_empty() && !matches!(prim, Primitive::Sys(_)) {
+            title.push_str(": ");
+        }
+        title.push_str(&doc.short_text());
+    }
+    if title.is_empty() {
+        view! {
+            <a href=href class="prim-code-a">
+                <code><span class=symbol_class>{ symbol }</span>{name}</code>
+            </a>
+        }
+    } else {
+        view! {
+            <a href=href class="prim-code-a">
+                <code class="prim-code" data-title=title><span class=symbol_class>{ symbol }</span>{name}</code>
+            </a>
+        }
+    }
+}
+
+pub fn prim_class(prim: Primitive) -> &'static str {
+    prim_sig_class(prim, None)
+}
+
+macro_rules! code_font {
+    ($class:literal) => {
+        concat!("code-font ", $class)
+    };
+}
+
+pub(crate) use code_font;
+
+fn sig_class(sig: Signature) -> &'static str {
+    match sig.args {
+        0 => code_font!("noadic-function"),
+        1 => code_font!("monadic-function"),
+        2 => code_font!("dyadic-function"),
+        3 => code_font!("triadic-function"),
+        4 => code_font!("tetradic-function"),
+        _ => code_font!(""),
+    }
+}
+
+fn prim_sig_class(prim: Primitive, sig: Option<Signature>) -> &'static str {
+    match prim {
+        Primitive::Identity => code_font!("stack-function"),
+        Primitive::Transpose => code_font!("monadic-function trans text-gradient"),
+        Primitive::Both => code_font!("monadic-modifier bi text-gradient"),
+        Primitive::Member => code_font!("dyadic-function caution text-gradient"),
+        Primitive::Couple => match sig.map(|sig| sig.args) {
+            None | Some(2) => code_font!("dyadic-function"),
+            Some(0) => code_font!("monadic-function aroace text-gradient"),
+            Some(1) => code_font!("monadic-function aro text-gradient"),
+            Some(_) => code_font!("dyadic-function poly text-gradient"),
+        },
+        prim if matches!(prim.class(), PrimClass::Stack | PrimClass::Debug)
+            && prim.modifier_args().is_none() =>
+        {
+            code_font!("stack-function")
+        }
+        prim if prim.class() == PrimClass::Constant => code_font!("number-literal"),
+        prim => {
+            if let Some(m) = prim.modifier_args() {
+                match m {
+                    0 | 1 => code_font!("monadic-modifier"),
+                    2 => code_font!("dyadic-modifier"),
+                    _ => code_font!("triadic-modifier"),
+                }
+            } else {
+                sig.or(prim.signature())
+                    .map(sig_class)
+                    .unwrap_or(code_font!(""))
+            }
+        }
+    }
+}
+
+fn binding_class(name: &str, docs: &BindingDocs) -> &'static str {
+    match name {
+        "Trans" | "Transgender" => code_font!("trans text-gradient"),
+        "Bi" | "Bisexual" => code_font!("bi text-gradient"),
+        "Pan" | "Pansexual" => code_font!("pan text-gradient"),
+        "Gay" => code_font!("gay text-gradient"),
+        "Lesbian" => code_font!("lesbian text-gradient"),
+        "Ace" | "Asexual" => code_font!("ace text-gradient"),
+        "Aro" | "Aromantic" => code_font!("aro text-gradient"),
+        "AroAce" => code_font!("aroace text-gradient"),
+        "Agender" => code_font!("agender text-gradient"),
+        "Nb" | "Enby" | "Nonbinary" | "NonBinary" => code_font!("nb text-gradient"),
+        "Fluid" | "Genderfluid" | "GenderFluid" => code_font!("fluid text-gradient"),
+        "Queer" | "Genderqueer" | "GenderQueer" => code_font!("queer text-gradient"),
+        "Poly" | "Polyamorous" => code_font!("poly text-gradient"),
+        _ => match docs.kind {
+            BindingDocsKind::Constant(_) => code_font!(""),
+            BindingDocsKind::Function { sig, .. } => sig_class(sig),
+            BindingDocsKind::Modifier(margs) => match margs {
+                1 => code_font!("monadic-modifier"),
+                2 => code_font!("dyadic-modifier"),
+                _ => code_font!("triadic-modifier"),
+            },
+            BindingDocsKind::Module { .. } => code_font!("module"),
+        },
     }
 }
 

--- a/pad/editor/src/utils.rs
+++ b/pad/editor/src/utils.rs
@@ -27,7 +27,7 @@ use web_sys::{
 
 use crate::{
     backend::{OutputItem, WebBackend},
-    code_font, prim_sig_class, binding_class,
+    binding_class, code_font, prim_sig_class,
 };
 
 #[derive(Clone)]
@@ -894,6 +894,7 @@ impl State {
     }
 }
 
+#[allow(clippy::mutable_key_type)]
 fn run_code_single(code: &str) -> (Vec<OutputItem>, Option<UiuaError>) {
     // Run
     let mut rt = init_rt();

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -19,6 +19,7 @@ pathdiff = "0.2.1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 uiua = {path = "..", default-features = false, features = ["batteries", "web"]}
+uiua-editor = {path = "../pad/editor"}
 unicode-segmentation = "1.10"
 urlencoding = "2"
 wasm-bindgen = "0.2.93"

--- a/site/src/examples.rs
+++ b/site/src/examples.rs
@@ -69,7 +69,7 @@ pub const EXAMPLES: &[&str] = &[
 #[test]
 fn test_examples() {
     use uiua_editor::backend::WebBackend;
-    
+
     for example in EXAMPLES {
         match uiua::Uiua::with_backend(WebBackend::default()).run_str(example) {
             Ok(mut comp) => {

--- a/site/src/examples.rs
+++ b/site/src/examples.rs
@@ -68,8 +68,10 @@ pub const EXAMPLES: &[&str] = &[
 #[cfg(test)]
 #[test]
 fn test_examples() {
+    use uiua_editor::backend::WebBackend;
+    
     for example in EXAMPLES {
-        match uiua::Uiua::with_backend(crate::backend::WebBackend::default()).run_str(example) {
+        match uiua::Uiua::with_backend(WebBackend::default()).run_str(example) {
             Ok(mut comp) => {
                 if let Some(diag) = comp.take_diagnostics().into_iter().next() {
                     panic!("Example failed:\n{example}\n{diag}");

--- a/site/src/markdown.rs
+++ b/site/src/markdown.rs
@@ -4,8 +4,9 @@ use comrak::{
 };
 use leptos::*;
 use uiua::{Inputs, Primitive, Token};
+use uiua_editor::{backend::fetch, Editor};
 
-use crate::{backend::fetch, editor::Editor, examples::LOGO, Hd, NotFound, Prim, ScrollToHash};
+use crate::{examples::LOGO, Hd, NotFound, Prim, ScrollToHash};
 
 #[component]
 #[allow(unused_braces)]
@@ -331,6 +332,8 @@ fn all_text<'a>(node: &'a AstNode<'a>) -> String {
 #[cfg(test)]
 #[test]
 fn text_code_blocks() {
+    use uiua_editor::backend::WebBackend;
+
     for entry in std::fs::read_dir("text").unwrap() {
         let entry = entry.unwrap();
         let path = entry.path();
@@ -364,8 +367,8 @@ fn text_code_blocks() {
 
         for (block, should_fail) in text_code_blocks(root) {
             eprintln!("Code block:\n{}", block);
-            let mut comp = uiua::Compiler::with_backend(crate::backend::WebBackend::default());
-            let mut env = uiua::Uiua::with_backend(crate::backend::WebBackend::default());
+            let mut comp = uiua::Compiler::with_backend(WebBackend::default());
+            let mut env = uiua::Uiua::with_backend(WebBackend::default());
             let res = comp
                 .load_str(&block)
                 .and_then(|comp| env.run_compiler(comp));

--- a/site/src/other.rs
+++ b/site/src/other.rs
@@ -1,9 +1,9 @@
 use leptos::*;
 use leptos_meta::*;
 use uiua::{Primitive, CONSTANTS};
+use uiua_editor::Editor;
 
 use crate::{
-    editor::Editor,
     markdown::{markdown_view, Markdown},
     Const, Hd, Prim, Prims,
 };

--- a/site/src/other_tutorial.rs
+++ b/site/src/other_tutorial.rs
@@ -3,8 +3,9 @@ use leptos::*;
 use leptos_meta::Title;
 use leptos_router::*;
 use uiua::{Primitive, SysOp};
+use uiua_editor::Editor;
 
-use crate::{title_markdown, Challenge, Editor, Hd, Prim, Prims};
+use crate::{title_markdown, Challenge, Hd, Prim, Prims};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Sequence)]
 pub enum OtherTutorialPage {

--- a/site/src/primitive.rs
+++ b/site/src/primitive.rs
@@ -435,7 +435,7 @@ fn inverse_row_impl(
 fn prim_docs() {
     use uiua::{PrimDocLine, Uiua};
     use uiua_editor::backend::WebBackend;
-    
+
     for prim in Primitive::non_deprecated() {
         for line in &prim.doc().lines {
             if let PrimDocLine::Example(ex) = line {

--- a/site/src/primitive.rs
+++ b/site/src/primitive.rs
@@ -2,8 +2,9 @@ use leptos::*;
 use leptos_meta::*;
 use leptos_router::*;
 use uiua::{PrimClass, PrimDocFragment, PrimDocLine, Primitive, SysOp};
+use uiua_editor::Editor;
 
-use crate::{editor::Editor, Hd, Prim, Prims};
+use crate::{Hd, Prim, Prims};
 
 fn doc_line_fragments_to_view(fragments: &[PrimDocFragment]) -> View {
     if fragments.is_empty() {
@@ -433,8 +434,8 @@ fn inverse_row_impl(
 #[test]
 fn prim_docs() {
     use uiua::{PrimDocLine, Uiua};
-
-    use crate::backend::WebBackend;
+    use uiua_editor::backend::WebBackend;
+    
     for prim in Primitive::non_deprecated() {
         for line in &prim.doc().lines {
             if let PrimDocLine::Example(ex) = line {

--- a/site/src/tutorial.rs
+++ b/site/src/tutorial.rs
@@ -5,10 +5,11 @@ use leptos::*;
 use leptos_meta::*;
 use leptos_router::*;
 use uiua::{Primitive, SysOp, EXAMPLE_UA};
+use uiua_editor::*;
 
 use crate::{
-    editor::*, markdown::Markdown, other_tutorial::OtherTutorialParams, title_markdown, Hd, Prim,
-    Prims,
+    markdown::Markdown, other_tutorial::OtherTutorialParams, title_markdown, Hd, Prim,
+    Prims, Challenge,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Sequence)]

--- a/site/src/tutorial.rs
+++ b/site/src/tutorial.rs
@@ -8,8 +8,8 @@ use uiua::{Primitive, SysOp, EXAMPLE_UA};
 use uiua_editor::*;
 
 use crate::{
-    markdown::Markdown, other_tutorial::OtherTutorialParams, title_markdown, Hd, Prim,
-    Prims, Challenge,
+    markdown::Markdown, other_tutorial::OtherTutorialParams, title_markdown, Challenge, Hd, Prim,
+    Prims,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Sequence)]

--- a/site/trunk.toml
+++ b/site/trunk.toml
@@ -4,7 +4,7 @@ no_sri = true
 public_url = "/"
 
 [watch]
-watch = [".", "../src"]
+watch = [".", "../src", "../pad/editor"]
 
 [serve]
 address = "0.0.0.0"


### PR DESCRIPTION
This is a first of hopefully a series of PRs with the final goal to package the editor component as a JS library. As the first step towards that goal - this change decouples and moves the editor component to it's own crate where it can be worked on without interfering with the website.

I don't recommend publishing the editor as it's own crate yet, because I'll likely make more changes to it.