### PR TITLE
Fix 0.12.3 on Nix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,8 +2086,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 [[package]]
 name = "libffi"
 version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
+source = "git+https://github.com/tov/libffi-rs?rev=d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b#d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b"
 dependencies = [
  "libc",
  "libffi-sys",
@@ -2096,8 +2095,7 @@ dependencies = [
 [[package]]
 name = "libffi-sys"
 version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
+source = "git+https://github.com/tov/libffi-rs?rev=d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b#d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b"
 dependencies = [
  "cc",
 ]
@@ -3973,6 +3971,7 @@ dependencies = [
  "js-sys",
  "json5",
  "libffi",
+ "libffi-sys",
  "libloading",
  "lockfree",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,8 @@ gif = {version = "0.13.1", optional = true}
 hound = {version = "3", optional = true}
 image = {version = "0.24.9", optional = true, default-features = false, features = ["bmp", "gif", "ico", "jpeg", "png", "qoi"]}
 json5 = {version = "0.4.1", optional = true}
-libffi = {version = "3", optional = true}
+libffi = { git = "https://github.com/tov/libffi-rs", rev = "d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b", optional = true }
+libffi-sys = { git = "https://github.com/tov/libffi-rs", rev = "d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b", optional = true }
 libloading = {version = "0.8.3", optional = true}
 pathfinding = {version = "4.9.1", optional = true}
 rustfft = {version = "6.2.0", optional = true}
@@ -131,7 +132,7 @@ default = [
   "clipboard",
   "batteries",
 ]
-ffi = ["libffi", "libloading"]
+ffi = ["libffi", "libffi-sys", "libloading"]
 fft = ["rustfft"]
 gif = ["dep:gif", "image", "color_quant"]
 invoke = ["open"]

--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712163089,
-        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
+        "lastModified": 1728492678,
+        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
+        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,6 @@
   inputs.crane = {
     url = "github:ipetkov/crane";
     inputs.nixpkgs.follows = "nixpkgs";
-    inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = { self, nixpkgs, flake-utils, crane }: 

--- a/flake.nix
+++ b/flake.nix
@@ -8,21 +8,34 @@
     inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, crane }: 
+  outputs = { self, nixpkgs, flake-utils, crane }:
     flake-utils.lib.eachDefaultSystem (system:
-    let 
-      pkgs = nixpkgs.legacyPackages.${system};
-      craneLib = crane.lib.${system};
-      uiua-crate = craneLib.buildPackage {
-        src = craneLib.cleanCargoSource (craneLib.path ./.);
-         buildInputs = nixpkgs.lib.optionals pkgs.stdenv.isDarwin [
-           pkgs.iconv
-           pkgs.darwin.apple_sdk.frameworks.AppKit
-           pkgs.darwin.apple_sdk.frameworks.CoreServices
-           pkgs.darwin.apple_sdk.frameworks.Foundation
-        ];
-      };
-    in
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        jpgFilter = path: type: builtins.match ".*jpg$" path != null;
+        pngFilter = path: type: builtins.match ".*png$" path != null;
+
+        cleanFilter = path: type:
+          (jpgFilter path type)
+          || (pngFilter path type)
+          || (craneLib.filterCargoSources path type);
+
+        craneLib = crane.lib.${system};
+        uiua-crate = craneLib.buildPackage {
+          src = pkgs.lib.cleanSourceWith {
+            src = (craneLib.path ./.);
+            filter = cleanFilter;
+            name = "source";
+          };
+          buildInputs = nixpkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.iconv
+            pkgs.darwin.apple_sdk.frameworks.AppKit
+            pkgs.darwin.apple_sdk.frameworks.CoreServices
+            pkgs.darwin.apple_sdk.frameworks.Foundation
+          ];
+        };
+      in
       {
         packages.default = uiua-crate;
         devShell = pkgs.mkShell {


### PR DESCRIPTION
This updates the `0.12.3` release to build on Nix. In particular, it will be possible to run

```
nix run github:uiua-lang/uiua/0.12-fix -- repl
```

to enter a Uiua REPL.