### PR TITLE
include Uiua386.tff in Nix builds

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -17,6 +17,7 @@ let
           (lib.fileset.fromSource (craneLib.cleanCargoSource ./.))
           ./src/primitive/assets
           ./site/Uiua386.ttf
+          ./src/algorithm/Uiua386.ttf
         ]
         ++ lib.optionals doCheck [
           ./site/favicon.ico


### PR DESCRIPTION
This PR fixes builds on Nix by including the `Uiua386.tff` file in builds.

After merging this PR, it should be possible to run

```
nix run github:uiua-lang/uiua -- repl
```

to enter a Uiua REPL.