### PR TITLE
remove references to a deleted file

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -16,7 +16,6 @@ let
         [
           (lib.fileset.fromSource (craneLib.cleanCargoSource ./.))
           ./src/primitive/assets
-          ./site/Uiua386.ttf
           ./src/algorithm/Uiua386.ttf
         ]
         ++ lib.optionals doCheck [


### PR DESCRIPTION
This PR makes `nix run .` work again. Without this, we receive errors like

```
╭── 22:33:56 ┄ nixos@nixos ┄ ~/projects/uiua ┄ 0f9d1097 ✓
╰─❯ nix run .
error: builder for '/nix/store/dg0bpnwlwih6kb4lrzhsp907pzikbql7-uiua-0.13.0-dev.3.drv' failed with exit code 101;
       last 10 log lines:
       >    Compiling uiua v0.13.0-dev.3 (/build/source)
       > error: couldn't read `src/algorithm/Uiua386.ttf`: No such file or directory (os error 2)
       >    --> src/algorithm/encode.rs:819:31
       >     |
       > 819 |             db.load_font_data(include_bytes!("Uiua386.ttf").to_vec());
       >     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       >     |
       >     = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
       >
       > error: could not compile `uiua` (lib) due to 1 previous error
       For full logs, run 'nix log /nix/store/dg0bpnwlwih6kb4lrzhsp907pzikbql7-uiua-0.13.0-dev.3.drv'.
```