### PR TITLE
Make more things public

### DIFF
--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -18,7 +18,8 @@ pub struct Assembly {
     /// A list of global bindings
     pub bindings: EcoVec<BindingInfo>,
     pub(crate) spans: EcoVec<Span>,
-    pub(crate) inputs: Inputs,
+    /// Inputs used to build the assembly
+    pub inputs: Inputs,
     pub(crate) dynamic_functions: EcoVec<DynFn>,
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -19,7 +19,8 @@ use crate::{
 pub struct Function {
     /// The function's id
     pub id: FunctionId,
-    signature: Signature,
+    /// The function's signature
+    pub signature: Signature,
     pub(crate) slice: FuncSlice,
     hash: u64,
     pub(crate) flags: FunctionFlags,


### PR DESCRIPTION
This change exposes a couple of struct fields for the public API. These are the fields I currently found useful for inspecting parsed code structure to reinterpret the code in a format that could be consumed outside Rust (with the goal to create a documentation generator). 

The two fields are:
- `Assembly#inputs` - The library may load more than one file and it's useful to know what files were used.
- `Function#signature` - When inspecting a function it's useful to know it's inferred signature.