### PR TITLE
fix(nix): add alsa-lib on linux

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   libffi,
   libiconv,
+  alsa-lib,
   darwin,
   rustPlatform,
   doCheck ? true,
@@ -34,6 +35,7 @@ let
     ];
     buildInputs =
       [ libffi ]
+      ++ lib.optionals stdenv.isLinux [ alsa-lib ]
       ++ lib.optionals stdenv.isDarwin (
         with darwin.apple_sdk.frameworks;
         [


### PR DESCRIPTION
After enabling the `full` feature by default in #607 the nix build on linux systems failed because the `alsa-lib` dependency was missing.