### PR TITLE
Implemented UI for dropped files

### DIFF
--- a/pad/editor/src/backend.rs
+++ b/pad/editor/src/backend.rs
@@ -30,7 +30,7 @@ struct VirtualStream {
 }
 
 thread_local! {
-    static FILES: RefCell<HashMap<PathBuf, Vec<u8>>> = RefCell::new(
+    pub static FILES: RefCell<HashMap<PathBuf, Vec<u8>>> = RefCell::new(
         [
             ("example.ua", EXAMPLE_UA),
             ("example.txt", EXAMPLE_TXT)
@@ -54,6 +54,10 @@ fn weewuh() {
 
 pub fn drop_file(path: PathBuf, contents: Vec<u8>) {
     FILES.with(|files| files.borrow_mut().insert(path, contents));
+}
+
+pub fn delete_file(path: &PathBuf) {
+    FILES.with(|files| files.borrow_mut().remove(path));
 }
 
 impl Default for WebBackend {

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -20,8 +20,8 @@ use uiua::{
 };
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use web_sys::{
-    DragEvent, Event, FileList, FileReader, HtmlAnchorElement, HtmlDivElement, HtmlInputElement, 
-    HtmlSelectElement, HtmlTextAreaElement, MouseEvent
+    DragEvent, Event, FileList, FileReader, HtmlAnchorElement, HtmlDivElement, HtmlInputElement,
+    HtmlSelectElement, HtmlTextAreaElement, MouseEvent,
 };
 
 use utils::*;
@@ -1509,7 +1509,7 @@ pub fn Editor<'a>(
 
     let file_tab_display = move || {
         let files = get_files_to_display().clone();
-        if files.len() == 0 {
+        if files.is_empty() {
             return view! {
                 <div></div>
             };

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -1749,12 +1749,18 @@ pub fn Editor<'a>(
                                 on:click=toggle_settings_open>
                                 "⚙️"
                             </button>
-                            <button
-                                class="editor-right-button"
-                                data-title="Upload file"
-                                on:click=upload_file_dialog>
-                                "📄"
-                            </button>
+                            {
+                                if mode == EditorMode::Pad {
+                                    Some(view!(<button
+                                        class="editor-right-button"
+                                        data-title="Upload file"
+                                        on:click=upload_file_dialog>
+                                        "📄"
+                                    </button>))
+                                } else {
+                                    None
+                                }
+                            }
                             <div id="example-tracker">{example_text}</div>
                         </div>
                     </div>

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -25,9 +25,9 @@ use web_sys::{
 };
 
 use utils::*;
-use utils::{element, get_ast_time, format_insert_file_code};
+use utils::{element, format_insert_file_code, get_ast_time};
 
-use backend::{drop_file, delete_file, OutputItem};
+use backend::{delete_file, drop_file, OutputItem};
 use js_sys::Date;
 use std::sync::OnceLock;
 
@@ -1286,16 +1286,16 @@ pub fn Editor<'a>(
         if files.length() == 0 {
             return;
         }
-        
+
         let total_files = files.length();
         let processed_files = Rc::new(Cell::new(0));
-        
+
         for i in 0..total_files {
             let file = files.get(i).unwrap();
             let file_name = file.name();
             let reader = FileReader::new().unwrap();
             reader.read_as_array_buffer(&file).unwrap();
-        
+
             let processed_files = Rc::clone(&processed_files);
             let on_load = Closure::wrap(Box::new(move |event: Event| {
                 let event = event.dyn_into::<web_sys::ProgressEvent>().unwrap();
@@ -1309,13 +1309,13 @@ pub fn Editor<'a>(
                 let path = PathBuf::from(&file_name);
                 drop_file(path.clone(), bytes.to_vec());
                 set_drag_message.set("");
-                
+
                 processed_files.set(processed_files.get() + 1);
                 if processed_files.get() == total_files {
                     run(true, false);
                 }
             }) as Box<dyn FnMut(_)>);
-        
+
             reader
                 .add_event_listener_with_callback("load", on_load.as_ref().unchecked_ref())
                 .unwrap();
@@ -1478,7 +1478,8 @@ pub fn Editor<'a>(
 
         let excluded_files = ["example.txt", "example.ua"];
         backend::FILES.with(|files| {
-            files.borrow()
+            files
+                .borrow()
                 .iter()
                 .filter(|(path, _)| !excluded_files.contains(&path.to_str().unwrap()))
                 .map(|(path, _)| path.clone())
@@ -1507,7 +1508,8 @@ pub fn Editor<'a>(
                 let path_clone = path.clone();
                 let on_insert = move |_: MouseEvent| {
                     let content = backend::FILES.with(|files| {
-                        files.borrow()
+                        files
+                            .borrow()
                             .iter()
                             .find(|(p, _)| *p == &path_clone)
                             .map(|(_, code)| code.clone())

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -19,7 +19,10 @@ use uiua::{
     now, seed_random, PrimClass, Primitive, Signature, SysOp, Token,
 };
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
-use web_sys::{DragEvent, Event, FileList, FileReader, HtmlAnchorElement, HtmlDivElement, HtmlInputElement, HtmlSelectElement, HtmlTextAreaElement, MouseEvent};
+use web_sys::{
+    DragEvent, Event, FileList, FileReader, HtmlAnchorElement, HtmlDivElement, HtmlInputElement, 
+    HtmlSelectElement, HtmlTextAreaElement, MouseEvent
+};
 
 use utils::*;
 use utils::{element, format_insert_file_code, get_ast_time};

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -12,7 +12,6 @@ use leptos::{
 };
 
 use leptos_router::{use_navigate, BrowserIntegration, History, LocationChange, NavigateOptions};
-use leptos::html::Input;
 use uiua::{
     format::{format_str, FormatConfig},
     is_ident_char, lex,
@@ -20,7 +19,7 @@ use uiua::{
     now, seed_random, PrimClass, Primitive, Signature, SysOp, Token,
 };
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
-use web_sys::{DragEvent, Event, FileList, FileReader, HtmlAnchorElement, HtmlDivElement, HtmlInputElement, HtmlSelectElement, HtmlTextAreaElement, InputEvent, MouseEvent};
+use web_sys::{DragEvent, Event, FileList, FileReader, HtmlAnchorElement, HtmlDivElement, HtmlInputElement, HtmlSelectElement, HtmlTextAreaElement, MouseEvent};
 
 use utils::*;
 use utils::{element, format_insert_file_code, get_ast_time};

--- a/pad/editor/src/utils.rs
+++ b/pad/editor/src/utils.rs
@@ -1412,7 +1412,7 @@ pub fn element<T: JsCast>(id: &str) -> T {
 pub fn format_insert_file_code(path: &PathBuf, content: Vec<u8>) -> String {
     let function = match path.extension().and_then(|ext| ext.to_str()) {
         Some("ua") => "~",
-        Some("txt") | Some("md") | None => "&fras",
+        Some("txt") | Some("md") | Some("json") | None => "&fras",
         _ => "&frab",
     };
 

--- a/pad/editor/src/utils.rs
+++ b/pad/editor/src/utils.rs
@@ -1,3 +1,6 @@
+use base64::engine::{general_purpose::URL_SAFE, Engine};
+use leptos::*;
+use std::path::PathBuf;
 use std::{
     borrow::Cow,
     cell::Cell,
@@ -6,9 +9,6 @@ use std::{
     str::FromStr,
     time::Duration,
 };
-use std::path::PathBuf;
-use base64::engine::{general_purpose::URL_SAFE, Engine};
-use leptos::*;
 
 use uiua::{
     ast::Item,

--- a/pad/editor/src/utils.rs
+++ b/pad/editor/src/utils.rs
@@ -6,7 +6,7 @@ use std::{
     str::FromStr,
     time::Duration,
 };
-
+use std::path::PathBuf;
 use base64::engine::{general_purpose::URL_SAFE, Engine};
 use leptos::*;
 
@@ -1406,5 +1406,21 @@ pub fn element<T: JsCast>(id: &str) -> T {
         elem
     } else {
         panic!("#{id} not found")
+    }
+}
+
+pub fn format_insert_file_code(path: &PathBuf, content: Vec<u8>) -> String {
+    let function = match path.extension().and_then(|ext| ext.to_str()) {
+        Some("ua") => "~",
+        Some("txt") | Some("md") | None => "&fras",
+        _ => "&frab",
+    };
+
+    let file_name = path.to_string_lossy().into_owned();
+    let byte_count = content.len();
+    if byte_count < 10000 {
+        format!("{function} {file_name:?}\n")
+    } else {
+        format!("# {byte_count} bytes\n# {function} {file_name:?}\n")
     }
 }

--- a/pad/editor/src/utils.rs
+++ b/pad/editor/src/utils.rs
@@ -1,6 +1,6 @@
 use base64::engine::{general_purpose::URL_SAFE, Engine};
 use leptos::*;
-use std::path::PathBuf;
+use std::path::Path;
 use std::{
     borrow::Cow,
     cell::Cell,
@@ -1409,7 +1409,7 @@ pub fn element<T: JsCast>(id: &str) -> T {
     }
 }
 
-pub fn format_insert_file_code(path: &PathBuf, content: Vec<u8>) -> String {
+pub fn format_insert_file_code(path: &Path, content: Vec<u8>) -> String {
     let function = match path.extension().and_then(|ext| ext.to_str()) {
         Some("ua") => "~",
         Some("txt") | Some("md") | Some("json") | None => "&fras",

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -32,6 +32,7 @@ features = [
   "Storage",
   "HtmlAudioElement",
   "HtmlBrElement",
+  "HtmlElement",
   "Selection",
   "Node",
   "Clipboard",

--- a/site/styles.css
+++ b/site/styles.css
@@ -1484,6 +1484,8 @@ a.clean {
     background-color: #294259;
     border-radius: 999px;
     cursor: pointer;
+    font-size: .75em;
+    line-height: 1em;
 
     @media (prefers-color-scheme: light) {
         background-color: #b3cece;

--- a/site/styles.css
+++ b/site/styles.css
@@ -1463,3 +1463,37 @@ a.clean {
         -webkit-text-stroke: 0.01em #fff8;
     }
 }
+
+.pad-files {
+    border-top: 0.1em solid #60646838;
+    padding: 0.3em;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.3em;
+
+    @media (prefers-color-scheme: light) {
+        border-color: #0000001a;
+    }
+}
+
+.pad-file-tab {
+    display: flex;
+    gap: 0.3em;
+    padding: 0.2em 0.5em;
+    background-color: #294259;
+    border-radius: 999px;
+    cursor: pointer;
+
+    @media (prefers-color-scheme: light) {
+        background-color: #b3cece;
+    }
+}
+
+.pad-file-tab-close {
+    opacity: 0.5;
+
+    &:hover {
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
This PR introduces a pad UI for displaying custom files dropped to the editor and available for access by Uiua code and some additional related changes for running the pad.

|Light mode|
|:-:|
|![image](https://github.com/user-attachments/assets/de41f430-3b95-49a6-a8d5-0068da7b2f30)|
|Dark Mode|
|![image](https://github.com/user-attachments/assets/e00633cd-3085-499a-b8ca-ae4cb3a7ca7b)|

Features and changes:
- New UI for displaying dropped files.
- Click on the file name to insert the code to load it (preserves inferring `&fras`, `&frab` ans `~`).
  - The "loading code" is no longer inserted upon dropping the file. The rationale is that it was coded to work when the code was empty, and the code wouldn't be inserted if there was already code there - which is very confusing. Now the code is inserted at the cursor on click which should be much more pleasant UX.
- Click on the "x" button to remove the file.
- Now handles all dropped files, not just the first one.
- Added a button next to settings to upload a file via a prompt (useful for mobile users).

The way the file list updates is a little hacky - it listens for changes to the `output` state and re-renders every time it changes. I could not find a better way to do it, but it seems to work and handles the cases where files are created/deleted by running code. 