### PR TITLE
fix(nix): include ./tests_special

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -23,6 +23,7 @@ let
         ++ lib.optionals doCheck [
           ./site/favicon.ico
           ./tests
+          ./tests_special
         ]
       );
     };


### PR DESCRIPTION
a35c979 broke tested builds because the introduced `tests_special` directory was not included in the builder environment