### PR TITLE
feat(nix): add fonts derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,8 @@
           craneLib = crane.mkLib pkgs;
         in
         {
-          packages.default = pkgs.callPackage ./package.nix { inherit craneLib; };
+          packages.default = pkgs.callPackage ./nix/package.nix { inherit craneLib; };
+          packages.fonts = pkgs.callPackage ./nix/fonts.nix {};
           devShells.default = pkgs.mkShell {
             inputsFrom = builtins.attrValues self'.packages;
             packages = with pkgs; [

--- a/nix/fonts.nix
+++ b/nix/fonts.nix
@@ -1,0 +1,17 @@
+{
+  lib,
+  runCommandLocal,
+}:
+runCommandLocal "uiua-fonts"
+  {
+    src = lib.fileset.toSource {
+      root = ../site;
+      fileset = lib.fileset.fileFilter ({ hasExt, ... }: hasExt "ttf") ../site;
+    };
+    uiua386 = ../src/algorithm/Uiua386.ttf;
+  }
+  ''
+    mkdir -p "$out/share/fonts/truetype"
+    cp "$src"/* "$out/share/fonts/truetype/"
+    cp "$uiua386" "$out/share/fonts/truetype/Uiua386.ttf"
+  ''

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -13,17 +13,17 @@
 let
   commonArgs = {
     src = lib.fileset.toSource {
-      root = ./.;
+      root = ../.;
       fileset = lib.fileset.unions (
         [
-          (lib.fileset.fromSource (craneLib.cleanCargoSource ./.))
-          ./src/primitive/assets
-          ./src/algorithm/Uiua386.ttf
+          (lib.fileset.fromSource (craneLib.cleanCargoSource ../.))
+          ../src/primitive/assets
+          ../src/algorithm/Uiua386.ttf
         ]
         ++ lib.optionals doCheck [
-          ./site/favicon.ico
-          ./tests
-          ./tests_special
+          ../site/favicon.ico
+          ../tests
+          ../tests_special
         ]
       );
     };


### PR DESCRIPTION
Introduces `packages.fonts` flake output containing the three Uiua fonts, including the patched DejaVu Sans Mono.