### PR TITLE
fix: add file extensions and shebang to the TextMate grammar

### DIFF
--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -2507,6 +2507,10 @@ mod tests {
             r##"{{
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "Uiua",
+	"firstLineMatch": "^#!/.*\buiua\b",
+	"fileTypes": [
+		"ua"
+	],
 	"patterns": [
 		{{
 			"include": "#comments"


### PR DESCRIPTION
This allows using the grammar with other tools supporting tmLanguage format. In particular, the grammar can be converted to `.sublime-syntax` format and used with tools such as [bat]. See [TextMate docs](https://macromates.com/manual/en/language_grammars#example_grammar).

(copied from uiua-lang/uiua-vscode#18)

[bat]: https://github.com/sharkdp/bat