### PR TITLE
fix for compiler crash on i686

### DIFF
--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -138,6 +138,8 @@ pub(crate) fn validate_size_impl(
     let size = elements * elem_size as f64;
     let max_mega = if cfg!(target_arch = "wasm32") {
         256
+    } else if cfg!(target_arch = "x86") {
+        256
     } else {
         4096
     };


### PR DESCRIPTION
Since there isn’t an iOS app, I thought maybe it could be a cool option to use the uiua repl from the [iSH](https://ish.app/) app on iOS (which emulates i686 alpine linux). When using the repl I encountered the below error. This two line change fixes it. And is only doing what is already being done for wasm32.

```
/+ [1 2 3 4]
The application panicked (crashed).
Message:  attempt to multiply with overflow
Location: src/algorithm/mod.rs:143

Backtrace omitted.

Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
    /+ [1 2 3 4]
Error: 
The compiler has crashed!
Hooray! You found a bug!
Please report this at http://github.com/uiua-lang/uiua/issues/new or on Discord at https://discord.gg/9CU2ME4kmn.

Uiua version 0.14.0-dev.2

code:
/+ [1 2 3 4]
```