### PR TITLE
Added a function to get normalized keys from a map

### DIFF
--- a/src/algorithm/map.rs
+++ b/src/algorithm/map.rs
@@ -610,6 +610,15 @@ impl MapKeys {
         present_indices.sort_unstable_by_key(|(_, i)| *i);
         present_indices.into_iter().map(|(i, _)| i).collect()
     }
+    /// Get the keys in the same order as map values
+    pub fn normalized_keys(&self) -> Value {
+        let present_indices = self.present_indices();
+        let mut new_keys = Vec::with_capacity(present_indices.len());
+        for i in present_indices {
+            new_keys.push(self.keys.row(i));
+        }
+        Value::from_row_values_infallible(new_keys)
+    }
     pub(crate) fn reverse(&mut self) {
         let present_indices = self.present_indices();
         let mid = present_indices.len() / 2;


### PR DESCRIPTION
This PR adds a function to return map keys as a value where each row is in the same order as the array values.

I am making a Uiua runtime library for JavaScript (https://github.com/ekgame/uiua-js) and I want to convert from Rust API's Value struct to a JSON object with all the equivalent information. The one thing stopping me is that the keys for maps are all jumbled up internally and include dummy values. I need this function as a utility to get the keys in the same order as the array values so I could properly represent a Uiua value in JavaScript.