### PR TITLE
fix: escape regex in `firstLineMatch`

### DIFF
--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -2573,7 +2573,7 @@ mod tests {
             r##"{{
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "Uiua",
-	"firstLineMatch": "^#!/.*\buiua\b",
+	"firstLineMatch": "^#!/.*\\buiua\\b",
 	"fileTypes": [
 		"ua"
 	],


### PR DESCRIPTION
Follow-up to #623