### PR TITLE
allow the --window option on nixos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,18 @@
         }:
         let
           craneLib = crane.mkLib pkgs;
+          libPath = with pkgs; lib.makeLibraryPath [
+            libGL
+            libxkbcommon
+            wayland
+            xorg.libX11
+            xorg.libXcursor
+            xorg.libXi
+            xorg.libXrandr
+          ];
         in
         {
-          packages.default = pkgs.callPackage ./nix/package.nix { inherit craneLib; };
+          packages.default = pkgs.callPackage ./nix/package.nix { inherit craneLib libPath; };
           packages.fonts = pkgs.callPackage ./nix/fonts.nix {};
           devShells.default = pkgs.mkShell {
             inputsFrom = builtins.attrValues self'.packages;
@@ -42,6 +51,7 @@
               rustc
               libffi
             ];
+            LD_LIBRARY_PATH = libPath;
           };
         };
     };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,5 +1,7 @@
 {
   craneLib,
+  libPath,
+  makeWrapper,
   stdenv,
   lib,
   pkg-config,
@@ -33,6 +35,7 @@ let
     nativeBuildInputs = [
       pkg-config
       rustPlatform.bindgenHook
+      makeWrapper
     ];
     buildInputs =
       [ libffi ]
@@ -55,6 +58,9 @@ let
   totalArgs = commonArgs // {
     inherit cargoArtifacts;
     cargoTestExtraArgs = "-- --skip format::generate_format_cfg_docs";
+    postInstall = ''
+      wrapProgram "$out/bin/uiua" --prefix LD_LIBRARY_PATH: "${libPath}"
+    '';
   };
 in
 craneLib.buildPackage totalArgs


### PR DESCRIPTION
On Nixos, it appears that the --window option gives a 'not supported' error.  
I have updated the flake.nix and package.nix based on the following:  "https://scvalex.net/posts/63/" which appears to fix it (at least on my machine :).
