### PR TITLE
Use bytemuck to replace most instances of mem::transmute.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,9 +764,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -3654,6 +3654,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -5797,6 +5798,7 @@ version = "0.15.0-dev.1"
 dependencies = [
  "arboard",
  "bitflags 2.6.0",
+ "bytemuck",
  "calamine",
  "clap",
  "color-backtrace",
@@ -5824,6 +5826,7 @@ dependencies = [
  "lockfree",
  "native-dialog",
  "notify",
+ "num-complex",
  "num_cpus",
  "once_cell",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.15.0-dev.1"
 [dependencies]
 # Core dependencies
 bitflags = {version = "2", features = ["serde"]}
+bytemuck = {version = "1.17", features = ["must_cast", "derive", "extern_crate_alloc"]}
 colored = "2"
 crossbeam-channel = "0.5.12"
 dashmap = {version = "5", features = ["serde"]}
@@ -80,6 +81,8 @@ image = {version = "0.24.9", optional = true, default-features = false, features
 json5 = {version = "0.4.1", optional = true}
 libffi = {version = "3", optional = true}
 libloading = {version = "0.8.3", optional = true}
+# NOTE: Including as a dependency to activate the bytemuck feature flag
+num-complex = {version = ">=0.4.1", optional = true, default-features = false, features = ["bytemuck"]}
 rustfft = {version = "6.2.0", optional = true}
 rustls-pemfile = {version = "2.1.2", optional = true}
 simple_excel_writer = {version = "0.2.0", optional = true}
@@ -140,7 +143,7 @@ default = [
   "batteries",
 ]
 ffi = ["libffi", "libloading"]
-fft = ["rustfft"]
+fft = ["rustfft", "num-complex"]
 font_shaping = ["cosmic-text", "sys-locale", "skrifa"]
 full = ["audio", "webcam", "window"] # Enables all optional features
 gif = ["dep:gif", "image", "color_quant"]

--- a/src/algorithm/dyadic/mod.rs
+++ b/src/algorithm/dyadic/mod.rs
@@ -10,9 +10,10 @@ use std::{
     cmp::Ordering,
     hash::{DefaultHasher, Hash, Hasher},
     iter::{once, repeat},
-    mem::{replace, swap, take, transmute},
+    mem::{replace, swap, take},
 };
 
+use bytemuck::allocation::cast_vec;
 use ecow::{eco_vec, EcoVec};
 use rand::prelude::*;
 #[cfg(not(target_arch = "wasm32"))]
@@ -1183,7 +1184,7 @@ fn derive_undices(mut indices: Vec<isize>, rank: usize, env: &Uiua) -> UiuaResul
             (rank - u) as isize
         };
     }
-    Ok(unsafe { transmute::<Vec<isize>, Vec<usize>>(indices) })
+    Ok(cast_vec(indices))
 }
 
 impl Value {

--- a/src/algorithm/map.rs
+++ b/src/algorithm/map.rs
@@ -5,6 +5,7 @@ use std::{
     mem::{replace, take},
 };
 
+use bytemuck::must_cast;
 use ecow::EcoVec;
 use serde::*;
 
@@ -764,12 +765,15 @@ pub fn remove_empty_rows(iter: impl ExactSizeIterator<Item = Value>) -> Value {
 
 const LOAD_FACTOR: f64 = 0.75;
 
+// NOTE: must_cast to f64 only works if f64 and u64 have same endianness.
+//       This is true of all currently supported platforms for rust,
+//       but may not be true in general. Swap out for f64::from_bits when
+//       the MSRV passes 1.83 to ensure correctness on all future platforms.
+
 // A NaN value used as empty, not the standard NaN.
-pub const EMPTY_NAN: f64 =
-    unsafe { std::mem::transmute(0x7ff8_0000_0000_0000u64 | 0x0000_0000_0000_0001) };
+pub const EMPTY_NAN: f64 = must_cast(0x7ff8_0000_0000_0000u64 | 0x0000_0000_0000_0001);
 // A NaN value used as a tombstone, not the standard NaN.
-pub const TOMBSTONE_NAN: f64 =
-    unsafe { std::mem::transmute(0x7ff8_0000_0000_0000u64 | 0x0000_0000_0000_0002) };
+pub const TOMBSTONE_NAN: f64 = must_cast(0x7ff8_0000_0000_0000u64 | 0x0000_0000_0000_0002);
 // A character value used as empty
 pub const EMPTY_CHAR: char = '\u{100001}';
 // A character value used as a tombstone

--- a/src/array.rs
+++ b/src/array.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use bitflags::bitflags;
+use bytemuck::must_cast;
 use ecow::{EcoString, EcoVec};
 use serde::{de::DeserializeOwned, *};
 
@@ -840,9 +841,12 @@ pub trait ArrayValue:
     }
 }
 
+// NOTE: must_cast to f64 only works if f64 and u64 have same endianness.
+//       This is true of all currently supported platforms for rust,
+//       but may not be true in general. Swap out for f64::from_bits when
+//       the MSRV passes 1.83 to ensure correctness on all future platforms.
 /// A NaN value that always compares as equal
-pub const WILDCARD_NAN: f64 =
-    unsafe { std::mem::transmute(0x7ff8_0000_0000_0000u64 | 0x0000_0000_0000_0003) };
+pub const WILDCARD_NAN: f64 = must_cast(0x7ff8_0000_0000_0000u64 | 0x0000_0000_0000_0003);
 /// A character value used as a wildcard that will equal any character
 pub const WILDCARD_CHAR: char = '\u{100000}';
 

--- a/src/complex.rs
+++ b/src/complex.rs
@@ -2,10 +2,11 @@
 
 use std::{f64::consts::E, fmt, ops::*};
 
+use bytemuck::{Pod, Zeroable};
 use serde::*;
 
 /// Uiua's complex number type
-#[derive(Debug, Clone, Copy, PartialOrd, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialOrd, Default, Serialize, Deserialize, Pod, Zeroable)]
 #[serde(from = "(f64, f64)", into = "(f64, f64)")]
 #[repr(C)]
 pub struct Complex {


### PR DESCRIPTION
Note that I am using bytemuck to create float constants. This works only if u64 and f64 have the same endianness. They do on all platforms I know of, so that shouldn't be a problem, but it would be better to use f64::from_bits for this. Unfortunately, that function isn't stable until rust 1.83, which is below the current MSRV for this project according to Cargo.toml.