### PR TITLE
fix(nix): use makeBinaryWrapper

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,7 +1,7 @@
 {
   craneLib,
   libPath,
-  makeWrapper,
+  makeBinaryWrapper,
   stdenv,
   lib,
   pkg-config,
@@ -35,7 +35,7 @@ let
     nativeBuildInputs = [
       pkg-config
       rustPlatform.bindgenHook
-      makeWrapper
+      makeBinaryWrapper
     ];
     buildInputs =
       [ libffi ]


### PR DESCRIPTION
It is recommended to use this, IBNLT because macOS expects shebang targets to be binaries. See [docs].

[docs]: https://nixos.org/manual/nixpkgs/unstable/#fun-makeWrapper
