### PR TITLE
Implemented downloading a file from the pad virtual file system

### DIFF
--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -1552,7 +1552,9 @@ pub fn Editor<'a>(
                             ),
                         )
                         .unwrap();
-                    anchor.set_attribute("download", &path_clone.to_string_lossy()).unwrap();
+                    anchor
+                        .set_attribute("download", &path_clone.to_string_lossy())
+                        .unwrap();
                     anchor.set_attribute("style", "display: none").unwrap();
                     doc.body().unwrap().append_child(&anchor).unwrap();
                     anchor.dyn_ref::<HtmlAnchorElement>().unwrap().click();

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -1531,6 +1531,35 @@ pub fn Editor<'a>(
                 };
 
                 let path_clone = path.clone();
+                let on_download = move |event: MouseEvent| {
+                    event.stop_propagation();
+                    let content = backend::FILES.with(|files| {
+                        files
+                            .borrow()
+                            .iter()
+                            .find(|(p, _)| *p == &path_clone)
+                            .map(|(_, code)| code.clone())
+                            .unwrap_or_default()
+                    });
+                    let doc = window().document().unwrap();
+                    let anchor = doc.create_element("a").unwrap();
+                    anchor
+                        .set_attribute(
+                            "href",
+                            &format!(
+                                "data:application/octet-stream;base64,{}",
+                                STANDARD.encode(content)
+                            ),
+                        )
+                        .unwrap();
+                    anchor.set_attribute("download", &path_clone.to_string_lossy()).unwrap();
+                    anchor.set_attribute("style", "display: none").unwrap();
+                    doc.body().unwrap().append_child(&anchor).unwrap();
+                    anchor.dyn_ref::<HtmlAnchorElement>().unwrap().click();
+                    set_timeout(move || anchor.remove(), Duration::from_millis(0));
+                };
+
+                let path_clone = path.clone();
                 let on_insert = move |_: MouseEvent| {
                     let content = backend::FILES.with(|files| {
                         files
@@ -1555,7 +1584,12 @@ pub fn Editor<'a>(
                     >
                         {&path_clone.to_string_lossy().into_owned()}
                         <span
-                            class="pad-file-tab-close"
+                            class="pad-file-tab-button"
+                            on:click=on_download
+                            inner_html="🠻"
+                        />
+                        <span
+                            class="pad-file-tab-button"
                             on:click=on_delete
                             inner_html="&times;"
                         />

--- a/site/styles.css
+++ b/site/styles.css
@@ -1539,8 +1539,9 @@ a.clean {
     }
 }
 
-.pad-file-tab-close {
+.pad-file-tab-button {
     opacity: 0.5;
+    scale: 1.2;
 
     &:hover {
         opacity: 1;


### PR DESCRIPTION
There have been a few requests to implement a function to download files from the pad's virtual file system. This change adds a button to the tab representing the file to download it.

![image](https://github.com/user-attachments/assets/21bada40-b64f-4e5f-886c-897d1f4b4874)

Fixes #655.