### PR TITLE
fix markdown parser of primitive's documentation

### DIFF
--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -2420,10 +2420,7 @@ pub(crate) fn parse_doc_line_fragments(mut line: &str) -> Vec<PrimDocFragment> {
                 curr = String::new();
                 kind = FragKind::Text;
             }
-            '*' if kind == FragKind::Strong
-                && chars.peek().map(|i| i.1) == Some('*')
-                && line[i + 2..].contains("**") =>
-            {
+            '*' if kind == FragKind::Strong && chars.peek().map(|i| i.1) == Some('*') => {
                 chars.next();
                 frags.push(PrimDocFragment::Strong(curr));
                 curr = String::new();


### PR DESCRIPTION
I noticed some markdown on docs is broken. This fixes it.
If a line contains strong text, the format of the line is not converted into HTML. Namely [each](https://www.uiua.org/docs/each) and [bits](https://www.uiua.org/docs/bits). You can see square brackets of function names are not turned into links although other lines are.
(Texts shown on hovering those functions using the language server in my text editor also have the same issue.)

In the code, the case of the changed line should indicate the end of the strong text. So it doesn't need to check if the line has another `**`, which I removed.
(I didn't know how to test things, but I locally built and checked the website and the language server to ensure that they are working correctly on those functions, at least.)
