### PR TITLE
Alternative pad layout

### DIFF
--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -256,37 +256,45 @@ pub fn Editor<'a>(
         let (input, seed) = format(do_format, set_cursor);
 
         // Run code
-        set_output.set(view!(<div class="running-text">"Running"</div>).into_view());
+        set_output.set(view! { <div class="running-text">"Running"</div> }.into_view());
         let allow_autoplay = !matches!(mode, EditorMode::Example) && get_autoplay();
         let render_output_item = move |item| match item {
             OutputItem::String(s) => {
                 if s.is_empty() {
-                    view!(<div class="output-item"><br/></div>).into_view()
+                    view! {
+                        <div class="output-item">
+                            <br />
+                        </div>
+                    }.into_view()
                 } else {
-                    view!(<div class="output-item">{s}</div>).into_view()
+                    view! { <div class="output-item">{s}</div> }.into_view()
                 }
             }
             OutputItem::Classed(class, s) => {
                 let class = format!("output-item {class}");
-                view!(<div class=class>{s}</div>).into_view()
+                view! { <div class=class>{s}</div> }.into_view()
             }
             OutputItem::Faint(s) => {
-                view!(<div class="output-item output-fainter">{s}</div>).into_view()
+                view! { <div class="output-item output-fainter">{s}</div> }.into_view()
             }
             OutputItem::Image(bytes, label) => {
                 let encoded = STANDARD.encode(bytes);
-                view!(<div class="output-media-wrapper">
-                    <div class="output-image-label">{label}</div>
-                    <img class="output-image" src={format!("data:image/png;base64,{encoded}")} />
-                </div>)
+                view! {
+                    <div class="output-media-wrapper">
+                        <div class="output-image-label">{label}</div>
+                        <img class="output-image" src=format!("data:image/png;base64,{encoded}") />
+                    </div>
+                }
                 .into_view()
             }
             OutputItem::Gif(bytes, label) => {
                 let encoded = STANDARD.encode(bytes);
-                view!(<div class="output-media-wrapper">
-                    <div class="output-image-label">{label}</div>
-                    <img class="output-image" src={format!("data:image/gif;base64,{encoded}")} />
-                </div>)
+                view! {
+                    <div class="output-media-wrapper">
+                        <div class="output-image-label">{label}</div>
+                        <img class="output-image" src=format!("data:image/gif;base64,{encoded}") />
+                    </div>
+                }
                 .into_view()
             }
             OutputItem::Audio(bytes, label) => {
@@ -294,28 +302,39 @@ pub fn Editor<'a>(
                 let src = format!("data:audio/wav;base64,{}", encoded);
                 let label = label.map(|s| format!("{s}:"));
                 if allow_autoplay {
-                    view!(<div class="output-media-wrapper">
-                        <div class="output-item output-audio-label">{label}</div>
-                        <audio class="output-audio" controls autoplay src=src/>
-                    </div>)
+                    view! {
+                        <div class="output-media-wrapper">
+                            <div class="output-item output-audio-label">{label}</div>
+                            <audio class="output-audio" controls autoplay src=src />
+                        </div>
+                    }
                     .into_view()
                 } else {
-                    view!(<div class="output-media-wrapper">
-                        <div class="output-item output-audio-label">{label}</div>
-                        <audio class="output-audio" controls src=src/>
-                    </div>)
+                    view! {
+                        <div class="output-media-wrapper">
+                            <div class="output-item output-audio-label">{label}</div>
+                            <audio class="output-audio" controls src=src />
+                        </div>
+                    }
                     .into_view()
                 }
             }
-            OutputItem::Svg(s, label) => view!(<div class="output-media-wrapper">
+            OutputItem::Svg(s, label) => view! {
+                <div class="output-media-wrapper">
                     <div class="output-image-label">{label}</div>
                     <img
                         class="output-image"
-                        src={format!("data:image/svg+xml;utf8, {}", urlencoding::encode(&s))}/>
-                </div>)
+                        src=format!("data:image/svg+xml;utf8, {}", urlencoding::encode(&s))
+                    />
+                </div>
+            }
             .into_view(),
             OutputItem::Report(report) => report_view(&report).into_view(),
-            OutputItem::Separator => view!(<div class="output-item"><hr/></div>).into_view(),
+            OutputItem::Separator => view! {
+                <div class="output-item">
+                    <hr />
+                </div>
+            }.into_view(),
         };
         set_timeout(
             move || {
@@ -965,7 +984,7 @@ pub fn Editor<'a>(
 
     // Glyph buttons
     // These are the buttons that appear above the editor and allow the user to insert glyphs
-    let make_glyph_button = |prim: Primitive| {
+    let make_glyph_button = move |prim: Primitive| {
         let text = prim
             .glyph()
             .map(Into::into)
@@ -995,16 +1014,18 @@ pub fn Editor<'a>(
         let onmouseover = move |_| {
             set_glyph_doc.set(
                 view! {
-                    <Prim prim=prim/>
-                    { prim.is_experimental().then(||
-                        view! {
-                            <span class="experimental" style="font-size: 0.8em;">
-                                "⚠️ Experimental"
-                            </span>
-                        }
-                    ) }
-                    <br/>
-                    { prim.doc().short_text().into_owned() }
+                    <Prim prim=prim />
+                    {prim
+                        .is_experimental()
+                        .then(|| {
+                            view! {
+                                <span class="experimental" style="font-size: 0.8em;">
+                                    "⚠️ Experimental"
+                                </span>
+                            }
+                        })}
+                    <br />
+                    {prim.doc().short_text().into_owned()}
                 }
                 .into_view(),
             );
@@ -1021,186 +1042,217 @@ pub fn Editor<'a>(
                     data-title=title
                     on:click=onclick
                     on:mouseover=onmouseover
-                    on:mouseleave=onmouseleave>
-                    <div class={prim_class(prim)}>{ text }</div>
+                    on:mouseleave=onmouseleave
+                >
+                    <div class=prim_class(prim)>{text}</div>
                 </button>
             }
             .into_view(),
         )
     };
-    let mut glyph_buttons: Vec<_> = Primitive::non_deprecated()
-        .filter_map(make_glyph_button)
-        .collect();
 
-    // Additional code buttons
-    for (glyph, title, class, surround, doc) in [
-        (
-            "_",
-            "strand",
-            "strand-span",
-            None,
-            "tutorial/arrays#creating-arrays",
-        ),
-        (
-            "[]",
-            "array",
-            "",
-            Some(('[', ']')),
-            "tutorial/arrays#creating-arrays",
-        ),
-        (
-            "{}",
-            "box array",
-            "",
-            Some(('{', '}')),
-            "tutorial/arrays#nested-arrays",
-        ),
-        (
-            "()",
-            "function",
-            "",
-            Some(('(', ')')),
-            "tutorial/functions#inline-functions",
-        ),
-        ("¯", "(`) negative", "number-literal", None, ""),
-        (
-            "@",
-            "character",
-            "string-literal-span",
-            None,
-            "tutorial/types#characters",
-        ),
-        (
-            "$",
-            "format/multiline string",
-            "string-literal-span",
-            None,
-            "tutorial/functions#format-strings",
-        ),
-        (
-            "\"",
-            "string",
-            "string-literal-span",
-            Some(('"', '"')),
-            "tutorial/types#characters",
-        ),
-        ("!", "macro", "", None, "tutorial/macros"),
-        ("^", "placeholder", "", None, "tutorial/custommodifiers"),
-        ("←", "(=) binding", "", None, "tutorial/bindings"),
-        (
-            "↚",
-            "(=~) private binding",
-            "",
-            None,
-            "tutorial/modules#visibility",
-        ),
-        ("~", "module", "", None, "tutorial/modules"),
-        (
-            "|",
-            "signature",
-            "",
-            None,
-            "tutorial/functions#stack-signatures",
-        ),
-        (
-            "#",
-            "comment",
-            "comment-span",
-            None,
-            "tutorial/basic#comments",
-        ),
-    ] {
-        let class = format!("glyph-button {class}");
-        // Navigate to the docs page on ctrl/shift+click
-        let onclick = move |event: MouseEvent| {
-            if !doc.is_empty() && os_ctrl(&event) {
-                // Open the docs page
-                window()
-                    .open_with_url_and_target(&format!("/{doc}"), "_blank")
-                    .unwrap();
-            } else if !doc.is_empty() && event.shift_key() {
-                // Redirect to the docs page
-                use_navigate()(&format!("/{doc}"), NavigateOptions::default());
-            } else if let Some((open, close)) = surround {
-                state.update(|state| surround_code(state, open, close));
-            } else {
-                state.update(|state| replace_code(state, glyph))
-            }
-        };
-        // Show the doc on mouseover
-        let onmouseover = move |_| {
-            if !doc.is_empty() {
-                set_glyph_doc.set(view!(<code>{ glyph }</code>" "{ title }).into_view());
-                _ = glyph_doc_element().style().remove_property("display");
-            }
-        };
-        glyph_buttons.push(
-            view! {
-                <button
-                    class=class
-                    data-title=title
-                    on:click=onclick
-                    on:mouseover=onmouseover
-                    on:mouseleave=onmouseleave>
-                    {glyph}
-                </button>
-            }
-            .into_view(),
-        );
-    }
-
-    // Additional functions combobox
-    let mut options = Vec::new();
-    let mut named_prims: Vec<Primitive> = Primitive::non_deprecated()
-        .filter(|prim| {
-            prim.glyph().is_none() && (get_show_experimental() || !prim.is_experimental())
-        })
-        .collect();
-    named_prims.sort_by(|a, b| {
-        (a.name().starts_with('&').cmp(&b.name().starts_with('&')))
-            .then_with(|| a.name().cmp(b.name()))
+    // Show or hide the glyph buttons
+    let (show_glyphs, set_show_glyphs) = create_signal(match mode {
+        EditorMode::Example => false,
+        EditorMode::Showcase | EditorMode::Pad => true,
     });
-    let max_name_len = named_prims
-        .iter()
-        .map(|prim| prim.name().chars().count())
-        .max()
-        .unwrap();
-    for prim in named_prims {
-        let class = format!("{} named-function-button", prim_class(prim));
-        let mut desc = prim.doc().short_text().to_string();
-        if desc.chars().count() > 30 {
-            desc = desc.chars().take(29).chain(['…']).collect();
-        }
-        let text = format!("{:max_name_len$} - {desc}", prim.name()).replace(' ', " ");
-        options.push(view!(<option
-            class=class
-            value={prim.name()}>
-            {text}
-        </option>));
-    }
-    let additional_on_change = move |event: Event| {
-        let select: HtmlSelectElement = event.target().unwrap().dyn_into().unwrap();
-        let name = select.value();
-        state.update(|state| replace_code(state, &name));
-        select.set_value("");
+
+    let glyph_buttons_container = move || {
+        show_glyphs.get().then(|| {
+            let mut glyph_buttons: Vec<_> = Primitive::non_deprecated()
+                .filter_map(make_glyph_button)
+                .collect();
+
+            // Additional code buttons
+            for (glyph, title, class, surround, doc) in [
+                (
+                    "_",
+                    "strand",
+                    "strand-span",
+                    None,
+                    "tutorial/arrays#creating-arrays",
+                ),
+                (
+                    "[]",
+                    "array",
+                    "",
+                    Some(('[', ']')),
+                    "tutorial/arrays#creating-arrays",
+                ),
+                (
+                    "{}",
+                    "box array",
+                    "",
+                    Some(('{', '}')),
+                    "tutorial/arrays#nested-arrays",
+                ),
+                (
+                    "()",
+                    "function",
+                    "",
+                    Some(('(', ')')),
+                    "tutorial/functions#inline-functions",
+                ),
+                ("¯", "(`) negative", "number-literal", None, ""),
+                (
+                    "@",
+                    "character",
+                    "string-literal-span",
+                    None,
+                    "tutorial/types#characters",
+                ),
+                (
+                    "$",
+                    "format/multiline string",
+                    "string-literal-span",
+                    None,
+                    "tutorial/functions#format-strings",
+                ),
+                (
+                    "\"",
+                    "string",
+                    "string-literal-span",
+                    Some(('"', '"')),
+                    "tutorial/types#characters",
+                ),
+                ("!", "macro", "", None, "tutorial/macros"),
+                ("^", "placeholder", "", None, "tutorial/custommodifiers"),
+                ("←", "(=) binding", "", None, "tutorial/bindings"),
+                (
+                    "↚",
+                    "(=~) private binding",
+                    "",
+                    None,
+                    "tutorial/modules#visibility",
+                ),
+                ("~", "module", "", None, "tutorial/modules"),
+                (
+                    "|",
+                    "signature",
+                    "",
+                    None,
+                    "tutorial/functions#stack-signatures",
+                ),
+                (
+                    "#",
+                    "comment",
+                    "comment-span",
+                    None,
+                    "tutorial/basic#comments",
+                ),
+            ] {
+                let class = format!("glyph-button {class}");
+                // Navigate to the docs page on ctrl/shift+click
+                let onclick = move |event: MouseEvent| {
+                    if !doc.is_empty() && os_ctrl(&event) {
+                        // Open the docs page
+                        window()
+                            .open_with_url_and_target(&format!("/{doc}"), "_blank")
+                            .unwrap();
+                    } else if !doc.is_empty() && event.shift_key() {
+                        // Redirect to the docs page
+                        use_navigate()(&format!("/{doc}"), NavigateOptions::default());
+                    } else if let Some((open, close)) = surround {
+                        state.update(|state| surround_code(state, open, close));
+                    } else {
+                        state.update(|state| replace_code(state, glyph))
+                    }
+                };
+                // Show the doc on mouseover
+                let onmouseover = move |_| {
+                    if !doc.is_empty() {
+                        set_glyph_doc.set(view! {
+                            <code>{glyph}</code>
+                            " "
+                            {title}
+                        }.into_view());
+                        _ = glyph_doc_element().style().remove_property("display");
+                    }
+                };
+                glyph_buttons.push(
+                    view! {
+                        <button
+                            class=class
+                            data-title=title
+                            on:click=onclick
+                            on:mouseover=onmouseover
+                            on:mouseleave=onmouseleave
+                        >
+                            {glyph}
+                        </button>
+                    }
+                    .into_view(),
+                );
+            }
+
+            // Additional functions combobox
+            let mut options = Vec::new();
+            let mut named_prims: Vec<Primitive> = Primitive::non_deprecated()
+                .filter(|prim| {
+                    prim.glyph().is_none() && (get_show_experimental() || !prim.is_experimental())
+                })
+                .collect();
+            named_prims.sort_by(|a, b| {
+                (a.name().starts_with('&').cmp(&b.name().starts_with('&')))
+                    .then_with(|| a.name().cmp(b.name()))
+            });
+            let max_name_len = named_prims
+                .iter()
+                .map(|prim| prim.name().chars().count())
+                .max()
+                .unwrap();
+            for prim in named_prims {
+                let class = format!("{} named-function-button", prim_class(prim));
+                let mut desc = prim.doc().short_text().to_string();
+                if desc.chars().count() > 30 {
+                    desc = desc.chars().take(29).chain(['…']).collect();
+                }
+                let text = format!("{:max_name_len$} - {desc}", prim.name()).replace(' ', " ");
+                options.push(view! {
+                    <option class=class value=prim.name()>
+                        {text}
+                    </option>
+                });
+            }
+            let additional_on_change = move |event: Event| {
+                let select: HtmlSelectElement = event.target().unwrap().dyn_into().unwrap();
+                let name = select.value();
+                state.update(|state| replace_code(state, &name));
+                select.set_value("");
+            };
+            glyph_buttons.push(
+                view! {
+                    <select
+                        id="additional-functions"
+                        class="additional-functions"
+                        on:change=additional_on_change
+                    >
+                        <option value="" disabled=true selected=true>
+                            "…"
+                        </option>
+                        {options}
+                    </select>
+                }
+                .into_view(),
+            );
+
+            view! { <div class="glyph-buttons">{glyph_buttons}</div> }
+        })
     };
-    glyph_buttons.push(
-        view! {
-            <select
-                id="additional-functions"
-                class="additional-functions"
-                on:change=additional_on_change>
-                <option value="" disabled=true selected=true>"…"</option>
-                { options }
-            </select>
-        }
-        .into_view(),
-    );
 
     // Select a class for the editor and code area
-    let editor_class = match mode {
-        EditorMode::Example => "small-editor",
-        EditorMode::Showcase | EditorMode::Pad => "medium-editor",
+    let editor_class = move || {
+        let editor_size = match mode {
+            EditorMode::Example => "small-editor",
+            EditorMode::Showcase | EditorMode::Pad => "medium-editor",
+        };
+
+        let editor_layout = match fullscreen_enabled.get() {
+            true => "fullscreen-editor",
+            false => "normal-editor",
+        };
+
+        format!("{} {}", editor_size, editor_layout)
     };
 
     // Hide the example arrows if there is only one example
@@ -1210,18 +1262,12 @@ pub fn Editor<'a>(
         ""
     };
 
-    // Show or hide the glyph buttons
-    let (show_glyphs, set_show_glyphs) = create_signal(match mode {
-        EditorMode::Example => false,
-        EditorMode::Showcase | EditorMode::Pad => true,
-    });
-
     // Glyphs toggle button
     let show_glyphs_icon = move || {
         if show_glyphs.get() {
-            view!(<span class="material-symbols-rounded">"keyboard_arrow_up"</span>)
+            view! { <span class="material-symbols-rounded">"keyboard_arrow_up"</span> }
         } else {
-            view!(<span class="material-symbols-rounded">"keyboard_arrow_down"</span>)
+            view! { <span class="material-symbols-rounded">"keyboard_arrow_down"</span> }
         }
     };
 
@@ -1234,21 +1280,30 @@ pub fn Editor<'a>(
     };
     let toggle_show_glyphs = move |_| set_show_glyphs.update(|s| *s = !*s);
 
-    // Hide the glyph buttons if the editor is small
-    let glyph_buttons_style = move || {
-        if show_glyphs.get() {
-            ""
+    let fullscreen_button_icon = move || {
+        if fullscreen_enabled.get() {
+            view! { <span class="material-symbols-rounded">"close_fullscreen"</span> }
         } else {
-            "display:none"
+            view! { <span class="material-symbols-rounded">"open_in_full"</span> }
         }
     };
+
+    let fullscreen_button_title = move || {
+        if fullscreen_enabled.get() {
+            "Collapse editor"
+        } else {
+            "Expand editor"
+        }
+    };
+
+    let toggle_fullscreen = move |_: MouseEvent| set_fullscreen_enabled.update(|s| *s = !*s);
 
     // Show the example number if there are multiple examples
     let examples_len = examples.len();
     let example_tracker_element = move || {
         (examples_len > 1)
             .then(|| format!("{}/{}", example.get() + 1, examples_len))
-            .map(|text| view!(<span id="example-tracker">{text}</span>))
+            .map(|text| view! { <span id="example-tracker">{text}</span> })
     };
 
     // Select a class for the next example button
@@ -1347,9 +1402,11 @@ pub fn Editor<'a>(
     let line_numbers = move || {
         (0..line_count.get().max(1))
             .map(|i| {
-                view!( <div class="code-line">
-                    <span class="code-span">{i + 1}</span>
-                </div>)
+                view! {
+                    <div class="code-line">
+                        <span class="code-span">{i + 1}</span>
+                    </div>
+                }
             })
             .collect::<Vec<_>>()
     };
@@ -1526,9 +1583,7 @@ pub fn Editor<'a>(
     let file_tab_display = move || {
         let files = get_files_to_display().clone();
         if files.is_empty() {
-            return view! {
-                <div></div>
-            };
+            return view! { <div></div> };
         }
 
         let file_list = get_files_to_display()
@@ -1591,40 +1646,23 @@ pub fn Editor<'a>(
 
                 let path_clone = path.clone();
                 view! {
-                    <div
-                        class="pad-file-tab"
-                        on:click=on_insert
-                    >
+                    <div class="pad-file-tab" on:click=on_insert>
                         {&path_clone.to_string_lossy().into_owned()}
-                        <span
-                            class="pad-file-tab-button"
-                            on:click=on_download
-                            inner_html="🠻"
-                        />
-                        <span
-                            class="pad-file-tab-button"
-                            on:click=on_delete
-                            inner_html="&times;"
-                        />
+                        <span class="pad-file-tab-button" on:click=on_download inner_html="🠻" />
+                        <span class="pad-file-tab-button" on:click=on_delete inner_html="&times;" />
                     </div>
                 }
             })
             .collect_view();
 
-        view! {
-            <div class="pad-files">
-                {file_list}
-            </div>
-        }
+        view! { <div class="pad-files">{file_list}</div> }
     };
 
     // Render
     view! {
         <div id="editor-wrapper">
-            <div id="editor">
-                <div style=glyph_buttons_style>
-                    <div class="glyph-buttons">{glyph_buttons}</div>
-                </div>
+            <div id="editor" class=editor_class>
+                {glyph_buttons_container}
                 {file_tab_display}
                 <div id="settings" style=settings_style>
                     <div id="settings-left">
@@ -1636,18 +1674,20 @@ pub fn Editor<'a>(
                                 max="1000000"
                                 width="3em"
                                 value=get_execution_limit
-                                on:input=on_execution_limit_change/>
-                            "s"
+                                on:input=on_execution_limit_change
+                            /> "s"
                         </div>
                         <div title="The maximum number of seconds of audio &ast will generate">
-                            <Prim prim=Primitive::Sys(SysOp::AudioStream) />" time:"
+                            <Prim prim=Primitive::Sys(SysOp::AudioStream) />
+                            " time:"
                             <input
                                 type="number"
                                 min="1"
                                 max="600"
                                 width="3em"
                                 value=get_ast_time
-                                on:input=on_ast_time_change/>
+                                on:input=on_ast_time_change
+                            />
                             "s"
                         </div>
                         <div title="Place the cursor on the left of the current token when formatting">
@@ -1655,69 +1695,84 @@ pub fn Editor<'a>(
                             <input
                                 type="checkbox"
                                 checked=get_right_to_left
-                                on:change=toggle_right_to_left/>
+                                on:change=toggle_right_to_left
+                            />
                         </div>
                         <div title="Automatically run pad links">
                             "Autorun links:"
-                            <input
-                                type="checkbox"
-                                checked=get_autorun
-                                on:change=toggle_autorun/>
+                            <input type="checkbox" checked=get_autorun on:change=toggle_autorun />
                         </div>
                         <div title="Automatically play audio">
                             "Autoplay audio:"
-                            <input
-                                type="checkbox"
-                                checked=get_autoplay
-                                on:change=toggle_autoplay/>
+                            <input type="checkbox" checked=get_autoplay on:change=toggle_autoplay />
                         </div>
                         <div title="Show experimental primitive glyphs">
                             "Show experimental:"
                             <input
                                 type="checkbox"
                                 checked=get_show_experimental
-                                on:change=toggle_show_experimental/>
+                                on:change=toggle_show_experimental
+                            />
                         </div>
                         <div title="Run and format together">
                             "Run on format:"
                             <input
                                 type="checkbox"
                                 checked=get_run_on_format
-                                on:change=toggle_run_on_format/>
+                                on:change=toggle_run_on_format
+                            />
                         </div>
                         <div title="Show line values to the right of the code">
                             "Show values:"
                             <input
                                 type="checkbox"
                                 checked=get_inlay_values
-                                on:change=toggle_inlay_values/>
+                                on:change=toggle_inlay_values
+                            />
                         </div>
                         <div>
-                            "Stack:"
-                            <select
-                                on:change=on_select_top_at_top>
-                                <option value="false" selected=get_top_at_top()>"Top at bottom"</option>
-                                <option value="true" selected=get_top_at_top()>"Top at top"</option>
+                            "Stack:" <select on:change=on_select_top_at_top>
+                                <option value="false" selected=get_top_at_top()>
+                                    "Top at bottom"
+                                </option>
+                                <option value="true" selected=get_top_at_top()>
+                                    "Top at top"
+                                </option>
                             </select>
                         </div>
                         <div>
-                            "Font size:"
-                            <select
-                                on:change=on_select_font_size>
-                                <option value="0.6em" selected={get_font_size() == "0.6em"}>"Scalar"</option>
-                                <option value="0.8em" selected={get_font_size() == "0.8em"}>"Small"</option>
-                                <option value="1em" selected={get_font_size() == "1em"}>"Normal"</option>
-                                <option value="1.2em" selected={get_font_size() == "1.2em"}>"Big"</option>
-                                <option value="1.4em" selected={get_font_size() == "1.4em"}>"Rank 3"</option>
+                            "Font size:" <select on:change=on_select_font_size>
+                                <option value="0.6em" selected=get_font_size() == "0.6em">
+                                    "Scalar"
+                                </option>
+                                <option value="0.8em" selected=get_font_size() == "0.8em">
+                                    "Small"
+                                </option>
+                                <option value="1em" selected=get_font_size() == "1em">
+                                    "Normal"
+                                </option>
+                                <option value="1.2em" selected=get_font_size() == "1.2em">
+                                    "Big"
+                                </option>
+                                <option value="1.4em" selected=get_font_size() == "1.4em">
+                                    "Rank 3"
+                                </option>
                             </select>
                         </div>
                         <div>
-                            "Font:"
-                            <select
-                                on:change=on_select_font>
-                                <option value="Uiua386" selected={get_font_name() == "Uiua386"}>"Uiua386"</option>
-                                <option value="Pixua" selected={get_font_name() == "Pixua"}>"Pixua"</option>
-                                <option value="DejaVuSansMono" selected={get_font_name() == "DejaVuSansMono"}>"DejaVu"</option>
+                            "Font:" <select on:change=on_select_font>
+                                <option value="Uiua386" selected=get_font_name() == "Uiua386">
+                                    "Uiua386"
+                                </option>
+                                <option value="Pixua" selected=get_font_name() == "Pixua">
+                                    "Pixua"
+                                </option>
+                                <option
+                                    value="DejaVuSansMono"
+                                    selected=get_font_name() == "DejaVuSansMono"
+                                >
+                                    "DejaVu"
+                                </option>
                             </select>
                         </div>
                         <button on:click=download_code>"Download Code"</button>
@@ -1728,165 +1783,203 @@ pub fn Editor<'a>(
                             <button
                                 class="info-button"
                                 data-title="Add # Experimental"
-                                on:click=on_insert_experimental>
+                                on:click=on_insert_experimental
+                            >
                                 "🧪"
                             </button>
-                            <button
-                                class="info-button"
-                                data-title=EDITOR_SHORTCUTS
-                                disabled>
+                            <button class="info-button" data-title=EDITOR_SHORTCUTS disabled>
                                 "🛈"
                             </button>
                         </div>
                         <div style="margin-right: 0.1em">
-                            "Tokens: "
-                            { move || token_count.get() }
+                            "Tokens: " {move || token_count.get()}
                         </div>
                     </div>
                 </div>
-                <div class=editor_class>
-                    <div id="code-area">
-                        <div id={glyph_doc_id} class="glyph-doc" style="display: none">
-                            { move || glyph_doc.get() }
-                            <div class="glyph-doc-ctrl-click">"Shift+click for more info (Ctrl/⌘+click for new tab)"</div>
-                        </div>
-                        <div
-                            id=code_outer_id
-                            class="code code-outer sized-code"
-                            style={format!("height: {}em;", code_height_em + 1.25 / 2.0)}>
-                            <div class="line-numbers">
-                                { line_numbers }
-                            </div>
-                            <div class="code-and-overlay">
-                                /////////////////////////
-                                // The text entry area //
-                                /////////////////////////
-                                <textarea
-                                    id=code_id
-                                    class="code-entry"
-                                    autocorrect="false"
-                                    autocapitalize="off"
-                                    spellcheck="false"
-                                    translate="no"
-                                    on:paste=code_paste
-                                    on:input=code_input
-                                    on:mousemove=code_mouse_move
-                                    on:mouseleave=code_mouse_leave
-                                    value=initial_code_str>
-                                </textarea>
-                                /////////////////////////
-                                <div
-                                    id=overlay_id
-                                    class="code-overlay">
-                                    { move || gen_code_view(&code_id(), &overlay.get()) }
-                                </div>
-                            </div>
-                        </div>
-                        <div id="code-right-side">
-                            <button
-                                id="glyphs-toggle-button"
-                                class="editor-right-button"
-                                data-title=show_glyphs_title
-                                on:click=toggle_show_glyphs>
-                                {show_glyphs_icon}
-                            </button>
 
-                            <button
-                                class="editor-right-button"
-                                data-title=toggle_settings_title
-                                on:click=toggle_settings_open>
-                                <span class="material-symbols-rounded">settings</span>
-                            </button>
-
-                            <button
-                                class="editor-right-button"
-                                data-title=copy_link_title
-                                on:click=copy_link>
-                                <span class="material-symbols-rounded">link</span>
-                            </button>
-
-                            {
-                                (mode == EditorMode::Pad).then(|| {
-                                    Some(view!(<button
-                                        class="editor-right-button"
-                                        data-title="Upload file"
-                                        on:click=upload_file_dialog>
-                                        <span class="material-symbols-rounded">upload</span>
-                                    </button>))
-                                })
-                            }
-                            
-                            {example_tracker_element}
+                <div id="code-area">
+                    <div id=glyph_doc_id class="glyph-doc" style="display: none">
+                        {move || glyph_doc.get()}
+                        <div class="glyph-doc-ctrl-click">
+                            "Shift+click for more info (Ctrl/⌘+click for new tab)"
                         </div>
                     </div>
-                    <div id=hover_id class="code-hover"/>
-                    <div class="output-frame">
-                        <div class="output-lines">
-                            <div class="output-diagnostics">
-                                { move || diag_output.get() }
+                    <div
+                        id=code_outer_id
+                        class="code code-outer sized-code"
+                        style=format!("height: {}em;", code_height_em + 1.25 / 2.0)
+                    >
+                        <div class="line-numbers">{line_numbers}</div>
+                        <div class="code-and-overlay">
+                            // ///////////////////////
+                            // The text entry area //
+                            // ///////////////////////
+                            <textarea
+                                id=code_id
+                                class="code-entry"
+                                autocorrect="false"
+                                autocapitalize="off"
+                                spellcheck="false"
+                                translate="no"
+                                on:paste=code_paste
+                                on:input=code_input
+                                on:mousemove=code_mouse_move
+                                on:mouseleave=code_mouse_leave
+                                value=initial_code_str
+                            ></textarea>
+                            // ///////////////////////
+                            <div id=overlay_id class="code-overlay">
+                                {move || gen_code_view(&code_id(), &overlay.get())}
                             </div>
-                            <div class="output-wrapper">
-                                <div id=format!("output-{id}") class="output sized-code">
-                                    { move || output.get() }
-                                    { move || get_state.get().challenge.as_ref().map(|chal| {
-                                        let intended = chal.intended_answer.clone();
-                                        let click_intended = move|_| {
-                                            get_state.get().set_code(&intended, Cursor::Ignore);
-                                        };
-                                        view! {
-                                        <div>
-                                            <hr/>
-                                            <button
-                                                class="glyph-button"
-                                                data-title="Show intended answer"
-                                                on:click=click_intended>
-                                                "📖"
-                                            </button>
-                                            {chal.best_answer.clone().map(|ans| {
-                                                let click_ans = move|_| {
-                                                    get_state.get().set_code(&ans, Cursor::Ignore);
-                                                };
-                                                view! {
+                        </div>
+                    </div>
+                    <div id="code-right-side">
+                        <button
+                            id="glyphs-toggle-button"
+                            class="editor-right-button"
+                            data-title=show_glyphs_title
+                            on:click=toggle_show_glyphs
+                        >
+                            {show_glyphs_icon}
+                        </button>
+
+                        <button
+                            class="editor-right-button"
+                            data-title=toggle_settings_title
+                            on:click=toggle_settings_open
+                        >
+                            <span class="material-symbols-rounded">settings</span>
+                        </button>
+
+                        <button
+                            class="editor-right-button"
+                            data-title=copy_link_title
+                            on:click=copy_link
+                        >
+                            <span class="material-symbols-rounded">link</span>
+                        </button>
+
+                        {(mode == EditorMode::Pad)
+                            .then(|| {
+                                Some(
+                                    view! {
+                                        <button
+                                            class="editor-right-button"
+                                            data-title="Upload file"
+                                            on:click=upload_file_dialog
+                                        >
+                                            <span class="material-symbols-rounded">upload</span>
+                                        </button>
+
+                                        <button
+                                            class="editor-right-button"
+                                            data-title=fullscreen_button_title
+                                            on:click=toggle_fullscreen
+                                        >
+                                            {fullscreen_button_icon}
+                                        </button>
+                                    },
+                                )
+                            })}
+
+                        {example_tracker_element}
+                    </div>
+                </div>
+
+                <div id=hover_id class="code-hover" />
+
+                <div class="output-frame">
+                    <div class="output-lines">
+                        <div class="output-diagnostics">{move || diag_output.get()}</div>
+                        <div class="output-wrapper">
+                            <div id=format!("output-{id}") class="output sized-code">
+                                {move || output.get()}
+                                {move || {
+                                    get_state
+                                        .get()
+                                        .challenge
+                                        .as_ref()
+                                        .map(|chal| {
+                                            let intended = chal.intended_answer.clone();
+                                            let click_intended = move |_| {
+                                                get_state.get().set_code(&intended, Cursor::Ignore);
+                                            };
+                                            view! {
+                                                <div>
+                                                    <hr />
                                                     <button
                                                         class="glyph-button"
-                                                        data-title="Show idiomatic answer"
-                                                        on:click=click_ans>
-                                                        "💡"
+                                                        data-title="Show intended answer"
+                                                        on:click=click_intended
+                                                    >
+                                                        "📖"
                                                     </button>
-                                                }
-                                            })}
-                                        </div>
-                                    }})}
-                                </div>
+                                                    {chal
+                                                        .best_answer
+                                                        .clone()
+                                                        .map(|ans| {
+                                                            let click_ans = move |_| {
+                                                                get_state.get().set_code(&ans, Cursor::Ignore);
+                                                            };
+                                                            view! {
+                                                                <button
+                                                                    class="glyph-button"
+                                                                    data-title="Show idiomatic answer"
+                                                                    on:click=click_ans
+                                                                >
+                                                                    "💡"
+                                                                </button>
+                                                            }
+                                                        })}
+                                                </div>
+                                            }
+                                        })
+                                }}
                             </div>
                         </div>
-                        <div id="code-buttons">
-                            <button
-                                class="code-button format-button run-format-button"
-                                on:click=move |_| {format(true, false);}
-                                data-title=" ctrl Enter - Format        \nshift Enter - Format and Run"
-                            >{ "Format" }</button>
-                            <button class="code-button" on:click=move |_| run(get_run_on_format(), false)>{ "Run" }</button>
-                            <button
-                                id="prev-example"
-                                class="code-button"
-                                style=example_arrow_style
-                                on:click=prev_example>{ "<" } </button>
-                            <button
-                                id="next-example"
-                                class=next_button_class
-                                style=example_arrow_style
-                                on:click=next_example>{ ">" } </button>
-                        </div>
+                    </div>
+                    <div id="code-buttons">
+                        <button
+                            class="code-button format-button run-format-button"
+                            on:click=move |_| {
+                                format(true, false);
+                            }
+                            data-title=" ctrl Enter - Format        \nshift Enter - Format and Run"
+                        >
+                            {"Format"}
+                        </button>
+                        <button
+                            class="code-button"
+                            on:click=move |_| run(get_run_on_format(), false)
+                        >
+                            {"Run"}
+                        </button>
+                        <button
+                            id="prev-example"
+                            class="code-button"
+                            style=example_arrow_style
+                            on:click=prev_example
+                        >
+                            {"<"}
+                        </button>
+                        <button
+                            id="next-example"
+                            class=next_button_class
+                            style=example_arrow_style
+                            on:click=next_example
+                        >
+                            {">"}
+                        </button>
                     </div>
                 </div>
-                { move || {
+
+                {move || {
                     let message = drag_message.get();
-                    (!message.is_empty()).then(|| view!(<div id="drag-message">{ message }</div>))
-                } }
+                    (!message.is_empty()).then(|| view! { <div id="drag-message">{message}</div> })
+                }}
             </div>
             <div id="editor-help">
-                { help.iter().map(|s| view!(<p>{s}</p>)).collect::<Vec<_>>() }
+                {help.iter().map(|s| view! { <p>{s}</p> }).collect::<Vec<_>>()}
             </div>
             <input
                 id=input_id
@@ -1938,13 +2031,19 @@ pub fn Prim(
     if title.is_empty() {
         view! {
             <a href=href class="prim-code-a">
-                <code><span class=symbol_class>{ symbol }</span>{name}</code>
+                <code>
+                    <span class=symbol_class>{symbol}</span>
+                    {name}
+                </code>
             </a>
         }
     } else {
         view! {
             <a href=href class="prim-code-a">
-                <code class="prim-code" data-title=title><span class=symbol_class>{ symbol }</span>{name}</code>
+                <code class="prim-code" data-title=title>
+                    <span class=symbol_class>{symbol}</span>
+                    {name}
+                </code>
             </a>
         }
     }

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -20,7 +20,8 @@ use uiua::{
 };
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use web_sys::{
-    console::{self, log_1}, DragEvent, Event, FileList, FileReader, HtmlAnchorElement, HtmlBodyElement, HtmlDivElement, HtmlInputElement, HtmlSelectElement, HtmlTextAreaElement, MouseEvent
+    DragEvent, Event, FileList, FileReader, HtmlAnchorElement, HtmlBodyElement, HtmlDivElement,
+    HtmlInputElement, HtmlSelectElement, HtmlTextAreaElement, MouseEvent,
 };
 
 use utils::*;
@@ -1703,7 +1704,11 @@ pub fn Editor<'a>(
         }
 
         let ratio = splitter_ratio.get();
-        format!("grid-template-columns: {}fr 0.25em {}fr", ratio, 1.0 - ratio)
+        format!(
+            "grid-template-columns: {}fr 0.25em {}fr",
+            ratio,
+            1.0 - ratio
+        )
     };
 
     window_event_listener(leptos_dom::ev::mousemove, move |event: MouseEvent| {
@@ -1918,7 +1923,6 @@ pub fn Editor<'a>(
                         {example_tracker_element}
                     </div>
 
-
                     <div id="code-area">
                         <div
                             id=code_outer_id
@@ -2039,10 +2043,7 @@ pub fn Editor<'a>(
                     </div>
                 </div>
 
-                <div
-                    class=draggable_splitter_class
-                    on:mousedown=start_dragging_splitter
-                ></div>
+                <div class=draggable_splitter_class on:mousedown=start_dragging_splitter></div>
 
                 {move || {
                     let message = drag_message.get();

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -1915,7 +1915,7 @@ pub fn Editor<'a>(
                                         </button>
 
                                         <button
-                                            class="editor-right-button"
+                                            class="editor-right-button expand-editor-button"
                                             data-title=fullscreen_button_title
                                             on:click=toggle_fullscreen
                                         >

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -7,8 +7,7 @@ use base64::engine::{general_purpose::STANDARD, Engine};
 
 use ev::mousemove;
 use leptos::{
-    ev::{keydown, keyup},
-    *,
+    ev::{keydown, keyup}, *
 };
 
 use leptos_router::{use_navigate, BrowserIntegration, History, LocationChange, NavigateOptions};
@@ -20,8 +19,7 @@ use uiua::{
 };
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use web_sys::{
-    DragEvent, Event, FileList, FileReader, HtmlAnchorElement, HtmlDivElement, HtmlInputElement,
-    HtmlSelectElement, HtmlTextAreaElement, MouseEvent,
+    DragEvent, Event, FileList, FileReader, HtmlAnchorElement, HtmlBodyElement, HtmlDivElement, HtmlInputElement, HtmlSelectElement, HtmlTextAreaElement, MouseEvent
 };
 
 use utils::*;
@@ -1296,7 +1294,13 @@ pub fn Editor<'a>(
         }
     };
 
-    let toggle_fullscreen = move |_: MouseEvent| set_fullscreen_enabled.update(|s| *s = !*s);
+    let toggle_fullscreen = move |_: MouseEvent| set_fullscreen_enabled.update(|s| {
+        *s = !*s;
+        let _ = document().body().unwrap().unchecked_into::<HtmlBodyElement>().style().set_property("overflow", match *s {
+            true => "hidden",
+            false => "auto",
+        });
+    });
 
     // Show the example number if there are multiple examples
     let examples_len = examples.len();
@@ -1797,42 +1801,14 @@ pub fn Editor<'a>(
                     </div>
                 </div>
 
-                <div id="code-area">
+                <div class="editor-area">
                     <div id=glyph_doc_id class="glyph-doc" style="display: none">
                         {move || glyph_doc.get()}
                         <div class="glyph-doc-ctrl-click">
                             "Shift+click for more info (Ctrl/⌘+click for new tab)"
                         </div>
                     </div>
-                    <div
-                        id=code_outer_id
-                        class="code code-outer sized-code"
-                        style=format!("height: {}em;", code_height_em + 1.25 / 2.0)
-                    >
-                        <div class="line-numbers">{line_numbers}</div>
-                        <div class="code-and-overlay">
-                            // ///////////////////////
-                            // The text entry area //
-                            // ///////////////////////
-                            <textarea
-                                id=code_id
-                                class="code-entry"
-                                autocorrect="false"
-                                autocapitalize="off"
-                                spellcheck="false"
-                                translate="no"
-                                on:paste=code_paste
-                                on:input=code_input
-                                on:mousemove=code_mouse_move
-                                on:mouseleave=code_mouse_leave
-                                value=initial_code_str
-                            ></textarea>
-                            // ///////////////////////
-                            <div id=overlay_id class="code-overlay">
-                                {move || gen_code_view(&code_id(), &overlay.get())}
-                            </div>
-                        </div>
-                    </div>
+
                     <div id="code-right-side">
                         <button
                             id="glyphs-toggle-button"
@@ -1883,6 +1859,39 @@ pub fn Editor<'a>(
                             })}
 
                         {example_tracker_element}
+                    </div>
+
+
+                    <div id="code-area">
+                        <div
+                            id=code_outer_id
+                            class="code code-outer sized-code"
+                            style=format!("height: {}em;", code_height_em + 1.25 / 2.0)
+                        >
+                            <div class="line-numbers">{line_numbers}</div>
+                            <div class="code-and-overlay">
+                                // ///////////////////////
+                                // The text entry area //
+                                // ///////////////////////
+                                <textarea
+                                    id=code_id
+                                    class="code-entry"
+                                    autocorrect="false"
+                                    autocapitalize="off"
+                                    spellcheck="false"
+                                    translate="no"
+                                    on:paste=code_paste
+                                    on:input=code_input
+                                    on:mousemove=code_mouse_move
+                                    on:mouseleave=code_mouse_leave
+                                    value=initial_code_str
+                                ></textarea>
+                                // ///////////////////////
+                                <div id=overlay_id class="code-overlay">
+                                    {move || gen_code_view(&code_id(), &overlay.get())}
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -1419,8 +1419,6 @@ pub fn Editor<'a>(
         handle_load_files(files);
     });
 
-    on_cleanup(move || listener.remove());
-
     // Line numbers
     let line_numbers = move || {
         (0..line_count.get().max(1))
@@ -1711,17 +1709,24 @@ pub fn Editor<'a>(
         )
     };
 
-    window_event_listener(leptos_dom::ev::mousemove, move |event: MouseEvent| {
-        if splitter_dragging.get() {
-            let mouse_x = event.client_x();
-            let editor_width = editor_wrapper_element().client_width();
-            let ratio = (mouse_x as f64 / editor_width as f64).clamp(0.1, 0.9);
-            set_splitter_ratio.set(ratio);
-        }
+    let mouse_move_listener =
+        window_event_listener(leptos_dom::ev::mousemove, move |event: MouseEvent| {
+            if splitter_dragging.get() {
+                let mouse_x = event.client_x();
+                let editor_width = editor_wrapper_element().client_width();
+                let ratio = (mouse_x as f64 / editor_width as f64).clamp(0.1, 0.9);
+                set_splitter_ratio.set(ratio);
+            }
+        });
+
+    let mouse_up_listener = window_event_listener(leptos_dom::ev::mouseup, move |_: MouseEvent| {
+        set_splitter_dragging.set(false);
     });
 
-    window_event_listener(leptos_dom::ev::mouseup, move |_: MouseEvent| {
-        set_splitter_dragging.set(false);
+    on_cleanup(move || {
+        mouse_move_listener.remove();
+        mouse_up_listener.remove();
+        listener.remove();
     });
 
     // Render

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -115,6 +115,7 @@ pub fn Editor<'a>(
     let get_code_cursor = move || get_code_cursor(&code_id());
     let (copied_link, set_copied_link) = create_signal(false);
     let (settings_open, set_settings_open) = create_signal(false);
+    let (fullscreen_enabled, set_fullscreen_enabled) = create_signal(false);
     let update_token_count = move |code: &str| {
         set_token_count.set(
             lex(code, (), &mut Default::default())
@@ -1216,7 +1217,14 @@ pub fn Editor<'a>(
     });
 
     // Glyphs toggle button
-    let show_glyphs_text = move || if show_glyphs.get() { "↥" } else { "↧" };
+    let show_glyphs_icon = move || {
+        if show_glyphs.get() {
+            view!(<span class="material-symbols-rounded">"keyboard_arrow_up"</span>)
+        } else {
+            view!(<span class="material-symbols-rounded">"keyboard_arrow_down"</span>)
+        }
+    };
+
     let show_glyphs_title = move || {
         if show_glyphs.get() {
             "Hide glyphs"
@@ -1237,8 +1245,11 @@ pub fn Editor<'a>(
 
     // Show the example number if there are multiple examples
     let examples_len = examples.len();
-    let example_text =
-        move || (examples_len > 1).then(|| format!("{}/{}", example.get() + 1, examples_len));
+    let example_tracker_element = move || {
+        (examples_len > 1)
+            .then(|| format!("{}/{}", example.get() + 1, examples_len))
+            .map(|text| view!(<span id="example-tracker">{text}</span>))
+    };
 
     // Select a class for the next example button
     let next_button_class = move || {
@@ -1773,36 +1784,39 @@ pub fn Editor<'a>(
                         </div>
                         <div id="code-right-side">
                             <button
-                                class="editor-right-button"
-                                data-title=copy_link_title
-                                on:click=copy_link>
-                                "🔗"
-                            </button>
-                            <button
                                 id="glyphs-toggle-button"
                                 class="editor-right-button"
                                 data-title=show_glyphs_title
-                                on:click=toggle_show_glyphs>{show_glyphs_text}
+                                on:click=toggle_show_glyphs>
+                                {show_glyphs_icon}
                             </button>
+
                             <button
                                 class="editor-right-button"
                                 data-title=toggle_settings_title
                                 on:click=toggle_settings_open>
-                                "⚙️"
+                                <span class="material-symbols-rounded">settings</span>
                             </button>
+
+                            <button
+                                class="editor-right-button"
+                                data-title=copy_link_title
+                                on:click=copy_link>
+                                <span class="material-symbols-rounded">link</span>
+                            </button>
+
                             {
-                                if mode == EditorMode::Pad {
+                                (mode == EditorMode::Pad).then(|| {
                                     Some(view!(<button
                                         class="editor-right-button"
                                         data-title="Upload file"
                                         on:click=upload_file_dialog>
-                                        "📄"
+                                        <span class="material-symbols-rounded">upload</span>
                                     </button>))
-                                } else {
-                                    None
-                                }
+                                })
                             }
-                            <div id="example-tracker">{example_text}</div>
+                            
+                            {example_tracker_element}
                         </div>
                     </div>
                     <div id=hover_id class="code-hover"/>

--- a/pad/editor/src/utils.rs
+++ b/pad/editor/src/utils.rs
@@ -152,10 +152,12 @@ impl State {
         area.style().set_property("width", &new_width).unwrap();
 
         let outer_new_width = format!("max(calc({width}px + 3.4em),100%)");
-        outer.style().set_property("width", &outer_new_width).unwrap();
+        outer
+            .style()
+            .set_property("width", &outer_new_width)
+            .unwrap();
 
         area.set_value(code);
-
     }
     pub fn refresh_code(&self) {
         let code = get_code(&self.code_id);
@@ -628,7 +630,7 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                             {short}
                         </span>
                     }
-                        .into_view(),
+                    .into_view(),
                 ),
                 CodeFragment::Ghost(short, None) => frag_views
                     .push(view! { <span class="code-span value-hint">{short}</span> }.into_view()),
@@ -754,7 +756,8 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                         <span class=space_class data-title="space character">
                                             " "
                                         </span>
-                                    }.into_view(),
+                                    }
+                                    .into_view(),
                                 )
                             } else {
                                 let title = if text.starts_with('@') {
@@ -768,7 +771,7 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                             {text}
                                         </span>
                                     }
-                                        .into_view(),
+                                    .into_view(),
                                 )
                             }
                         }
@@ -802,7 +805,8 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                     <span class=class data-title=title>
                                         {text}
                                     </span>
-                                }.into_view(),
+                                }
+                                .into_view(),
                             )
                         }
                         SpanKind::Placeholder(_) => {
@@ -813,7 +817,8 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                     <span class=class data-title=title>
                                         {text}
                                     </span>
-                                }.into_view(),
+                                }
+                                .into_view(),
                             )
                         }
                         SpanKind::Label => {
@@ -845,7 +850,7 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                         {text}
                                     </span>
                                 }
-                                    .into_view(),
+                                .into_view(),
                             )
                         }
                         SpanKind::FuncDelim(sig, set_inverses) => {
@@ -860,7 +865,8 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                     <span class=class data-title=title>
                                         {text}
                                     </span>
-                                }.into_view(),
+                                }
+                                .into_view(),
                             )
                         }
                         SpanKind::Subscript(prim, _) => {
@@ -875,7 +881,8 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                     <span class=class data-title=title>
                                         {text}
                                     </span>
-                                }.into_view(),
+                                }
+                                .into_view(),
                             )
                         }
                         SpanKind::Ident {
@@ -943,7 +950,8 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                     <span class=class data-title=title>
                                         {text}
                                     </span>
-                                }.into_view(),
+                                }
+                                .into_view(),
                             )
                         }
                         _ => {
@@ -1234,7 +1242,9 @@ pub fn report_view(report: &Report) -> impl IntoView {
             }
         }
         frags.push(match frag {
-            ReportFragment::Plain(s) => view! { <span class="output-report">{s}</span> }.into_view(),
+            ReportFragment::Plain(s) => {
+                view! { <span class="output-report">{s}</span> }.into_view()
+            }
             ReportFragment::Faint(s) => {
                 view! { <span class="output-report output-faint">{s}</span> }.into_view()
             }

--- a/pad/editor/src/utils.rs
+++ b/pad/editor/src/utils.rs
@@ -149,10 +149,13 @@ impl State {
         let rect = &virtual_rect(&area, code);
         let width = rect.width();
         let new_width = format!("max(calc({width}px + 1em),100%)");
-        area.style().set_property("width", "auto").unwrap();
         area.style().set_property("width", &new_width).unwrap();
 
+        let outer_new_width = format!("max(calc({width}px + 3.4em),100%)");
+        outer.style().set_property("width", &outer_new_width).unwrap();
+
         area.set_value(code);
+
     }
     pub fn refresh_code(&self) {
         let code = get_code(&self.code_id);
@@ -590,11 +593,11 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                     .unwrap();
             }
         };
-        let view = view!(<span
-            class=class
-            data-title=title
-            on:mouseover=onmouseover
-            on:click=onclick>{text}</span>)
+        let view = view! {
+            <span class=class data-title=title on:mouseover=onmouseover on:click=onclick>
+                {text}
+            </span>
+        }
         .into_view();
         frag_views.push(view);
     }
@@ -604,7 +607,11 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
     let mut line_views = Vec::new();
     for line in frags {
         if line.is_empty() {
-            line_views.push(view!(<div class="code-line"><br/></div>));
+            line_views.push(view! {
+                <div class="code-line">
+                    <br />
+                </div>
+            });
             continue;
         }
         let mut frag_views = Vec::new();
@@ -613,15 +620,19 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
             match frag {
                 CodeFragment::Unspanned(s) => {
                     // logging::log!("unspanned escaped: `{}`", s);
-                    frag_views.push(view!(<span class="code-span">{s}</span>).into_view())
+                    frag_views.push(view! { <span class="code-span">{s}</span> }.into_view())
                 }
                 CodeFragment::Ghost(short, Some(long)) => frag_views.push(
-                    view!(<span class="code-span value-hint" data-title=long>{short}</span>)
+                    view! {
+                        <span class="code-span value-hint" data-title=long>
+                            {short}
+                        </span>
+                    }
                         .into_view(),
                 ),
                 CodeFragment::Ghost(short, None) => frag_views
-                    .push(view!(<span class="code-span value-hint">{short}</span>).into_view()),
-                CodeFragment::Br => frag_views.push(view!(<br/>).into_view()),
+                    .push(view! { <span class="code-span value-hint">{short}</span> }.into_view()),
+                CodeFragment::Br => frag_views.push(view! { <br /> }.into_view()),
                 CodeFragment::Span(text, kind) => {
                     let color_class = match &kind {
                         SpanKind::Primitive(prim, sig) => prim_sig_class(*prim, *sig),
@@ -669,11 +680,16 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                 }
                             };
                             let text = format!("{text}{next_text}");
-                            let view = view!(<span
+                            let view = view! {
+                                <span
                                     class=class
                                     data-title=title
                                     on:mouseover=onmouseover
-                                    on:click=onclick>{text}</span>)
+                                    on:click=onclick
+                                >
+                                    {text}
+                                </span>
+                            }
                             .into_view();
                             frag_views.push(view)
                         }
@@ -731,10 +747,14 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                 let space_class =
                                     format!("code-span space-character {}", color_class);
                                 frag_views.push(
-                                    view!(
-                                        <span class=class data-title="space character">@</span>
-                                        <span class=space_class data-title="space character">" "</span>
-                                    ).into_view(),
+                                    view! {
+                                        <span class=class data-title="space character">
+                                            @
+                                        </span>
+                                        <span class=space_class data-title="space character">
+                                            " "
+                                        </span>
+                                    }.into_view(),
                                 )
                             } else {
                                 let title = if text.starts_with('@') {
@@ -743,7 +763,11 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                     "string"
                                 };
                                 frag_views.push(
-                                    view!(<span class=class data-title=title>{text}</span>)
+                                    view! {
+                                        <span class=class data-title=title>
+                                            {text}
+                                        </span>
+                                    }
                                         .into_view(),
                                 )
                             }
@@ -757,11 +781,16 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                     window().open_with_url_and_target(&path, "_blank").unwrap();
                                 }
                             };
-                            let view = view!(<span
-                                class=class
-                                data-title=title
-                                on:mouseover=onmouseover
-                                on:click=onclick>{text}</span>)
+                            let view = view! {
+                                <span
+                                    class=class
+                                    data-title=title
+                                    on:mouseover=onmouseover
+                                    on:click=onclick
+                                >
+                                    {text}
+                                </span>
+                            }
                             .into_view();
                             frag_views.push(view);
                         }
@@ -769,14 +798,22 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                             let class = format!("code-span {}", color_class);
                             let title = format!("{kind:?}").to_lowercase();
                             frag_views.push(
-                                view!(<span class=class data-title=title>{text}</span>).into_view(),
+                                view! {
+                                    <span class=class data-title=title>
+                                        {text}
+                                    </span>
+                                }.into_view(),
                             )
                         }
                         SpanKind::Placeholder(_) => {
                             let class = format!("code-span {}", color_class);
                             let title = "placeholder";
                             frag_views.push(
-                                view!(<span class=class data-title=title>{text}</span>).into_view(),
+                                view! {
+                                    <span class=class data-title=title>
+                                        {text}
+                                    </span>
+                                }.into_view(),
                             )
                         }
                         SpanKind::Label => {
@@ -803,7 +840,11 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                 components[0], components[1], components[2]
                             );
                             frag_views.push(
-                                view!(<span class="code-span" style=style data-title="label">{text}</span>)
+                                view! {
+                                    <span class="code-span" style=style data-title="label">
+                                        {text}
+                                    </span>
+                                }
                                     .into_view(),
                             )
                         }
@@ -815,7 +856,11 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                 title.push_str(&set_inverses.to_string());
                             }
                             frag_views.push(
-                                view!(<span class=class data-title=title>{text}</span>).into_view(),
+                                view! {
+                                    <span class=class data-title=title>
+                                        {text}
+                                    </span>
+                                }.into_view(),
                             )
                         }
                         SpanKind::Subscript(prim, _) => {
@@ -826,7 +871,11 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                                 "subscript".into()
                             };
                             frag_views.push(
-                                view!(<span class=class data-title=title>{text}</span>).into_view(),
+                                view! {
+                                    <span class=class data-title=title>
+                                        {text}
+                                    </span>
+                                }.into_view(),
                             )
                         }
                         SpanKind::Ident {
@@ -890,18 +939,22 @@ pub fn gen_code_view(id: &str, code: &str) -> View {
                             let class =
                                 format!("code-span {} {}", binding_class(&text, &docs), private);
                             frag_views.push(
-                                view!(<span class=class data-title=title>{text}</span>).into_view(),
+                                view! {
+                                    <span class=class data-title=title>
+                                        {text}
+                                    </span>
+                                }.into_view(),
                             )
                         }
                         _ => {
                             let class = format!("code-span {color_class}");
-                            frag_views.push(view!(<span class=class>{text}</span>).into_view())
+                            frag_views.push(view! { <span class=class>{text}</span> }.into_view())
                         }
                     }
                 }
             }
         }
-        line_views.push(view!(<div class="code-line">{frag_views}</div>))
+        line_views.push(view! { <div class="code-line">{frag_views}</div> })
     }
     line_views.into_view()
 }
@@ -1172,23 +1225,21 @@ pub fn report_view(report: &Report) -> impl IntoView {
             if range.contains(&i) {
                 if range.start == i {
                     let omitted_count = newline_indices.len() - 20;
-                    frags.push(view!(<br/>).into_view());
-                    frags.push(view!(<br/>).into_view());
-                    frags.push(view! {
-                        <span class="output-report">{format!("     ...{omitted_count} omitted...")}</span>
-                    }.into_view());
-                    frags.push(view!(<br/>).into_view());
+                    frags.push(view! { <br /> }.into_view());
+                    frags.push(view! { <br /> }.into_view());
+                    frags.push(view! { <span class="output-report">{format!("     ...{omitted_count} omitted...")}</span> }.into_view());
+                    frags.push(view! { <br /> }.into_view());
                 }
                 continue;
             }
         }
         frags.push(match frag {
-            ReportFragment::Plain(s) => view!(<span class="output-report">{s}</span>).into_view(),
+            ReportFragment::Plain(s) => view! { <span class="output-report">{s}</span> }.into_view(),
             ReportFragment::Faint(s) => {
-                view!(<span class="output-report output-faint">{s}</span>).into_view()
+                view! { <span class="output-report output-faint">{s}</span> }.into_view()
             }
             ReportFragment::Fainter(s) => {
-                view!(<span class="output-report output-fainter">{s}</span>).into_view()
+                view! { <span class="output-report output-fainter">{s}</span> }.into_view()
             }
             ReportFragment::Colored(s, kind) => {
                 if frags.is_empty() {
@@ -1203,7 +1254,7 @@ pub fn report_view(report: &Report) -> impl IntoView {
                     ReportKind::Diagnostic(DiagnosticKind::Style) => "output-report output-style",
                     ReportKind::Diagnostic(DiagnosticKind::Info) => "output-report output-info",
                 };
-                view!(<span class=class>{s}</span>).into_view()
+                view! { <span class=class>{s}</span> }.into_view()
             }
             ReportFragment::Newline => {
                 frag_lines.push((Vec::new(), false));
@@ -1218,11 +1269,9 @@ pub fn report_view(report: &Report) -> impl IntoView {
         } else {
             "output-line"
         };
-        frags.push(view!(<div class=class>{line}</div>).into_view());
+        frags.push(view! { <div class=class>{line}</div> }.into_view());
     }
-    view! {
-        <div style="font-family: inherit">{frags}</div>
-    }
+    view! { <div style="font-family: inherit">{frags}</div> }
 }
 
 pub fn progressive_strings(input: &str) -> Vec<String> {

--- a/site/index.html
+++ b/site/index.html
@@ -38,6 +38,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="A stack-based array programming language" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0" />
   <link data-trunk rel="rust" data-wasm-opt="s" />
   <link data-trunk rel="copy-file" href="404.html" />
   <link data-trunk rel="css" href="styles.css" />

--- a/site/styles.css
+++ b/site/styles.css
@@ -126,7 +126,7 @@ li {
         background-color: #171d22;
     }
 
-    #editor {
+    .editor {
         outline: 0.1em solid #606468;
         background-color: #19232d;
     }
@@ -210,7 +210,7 @@ li {
         background-color: #c6e7ec;
     }
 
-    #editor {
+    .editor {
         background-color: #dff2f3;
         outline: 0.1em solid #0004;
     }
@@ -390,7 +390,7 @@ li {
     width: 0;
 }
 
-#editor {
+.editor {
     border-radius: 0.5em;
     position: relative;
 }
@@ -1568,6 +1568,17 @@ a.clean {
     cursor: help;
 }
 
+.draggable-splitter {
+    grid-area: draggable;
+    cursor: ew-resize;
+    display: none;
+    background-color: #60646838;
+
+    &:hover, &.active {
+        background-color: #60646880;
+    }
+}
+
 .normal-editor {
     display: grid;
     grid-template-areas:
@@ -1584,12 +1595,12 @@ a.clean {
 .fullscreen-editor {
     display: grid;
     grid-template-areas:
-        'glyphs output'
-        'files output'
-        'settings output'
-        'editor output'
+        'glyphs draggable output'
+        'files draggable output'
+        'settings draggable output'
+        'editor draggable output'
         ;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr 0.25em 1fr;
     grid-template-rows: auto auto auto 1fr;
 
     border-radius: 0 !important;
@@ -1625,7 +1636,6 @@ a.clean {
     }
 
     .output-frame {
-        border-left: 0.1em solid #60646838;
         display: grid;
         grid-template-areas:
             'actions'
@@ -1654,5 +1664,9 @@ a.clean {
     .output-diagnostics {
         margin: 0;
         padding: 0.4em;
+    }
+
+    .draggable-splitter {
+        display: block;
     }
 }

--- a/site/styles.css
+++ b/site/styles.css
@@ -473,10 +473,15 @@ option,
     width: 3em;
 }
 
-#code-area {
+.editor-area {
     grid-area: editor;
     position: relative;
+    overflow: hidden;
+}
+
+#code-area {
     overflow: auto;
+    height: 100%;
 }
 
 .code-outer {
@@ -631,7 +636,7 @@ option,
 }
 
 #code-buttons {
-    margin: 0.2em 0.2em 0.2em 0;
+    margin: 0.2em;
     display: flex;
     flex-wrap: nowrap;
     right: 0;
@@ -733,6 +738,7 @@ option,
     font-size: min(1em, 3vw);
     align-items: center;
     gap: 0.25em;
+    z-index: 2;
 }
 
 .editor-right-button {
@@ -1515,18 +1521,21 @@ a.clean {
     }
 }
 
-.pad-files {
+.glyph-buttons + .pad-files {
     border-top: 0.1em solid #60646838;
+
+    @media (prefers-color-scheme: light) {
+        border-color: #0000001a;
+    }
+}
+
+.pad-files {
     padding: 0.3em;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
     gap: 0.3em;
     grid-area: files;
-
-    @media (prefers-color-scheme: light) {
-        border-color: #0000001a;
-    }
 }
 
 .pad-file-tab {
@@ -1607,7 +1616,7 @@ a.clean {
 
     .output-lines {
         width: 100%;
-        overflow-x: unset;
+        overflow: auto;
     }
 
     .output-wrapper {
@@ -1616,8 +1625,24 @@ a.clean {
     }
 
     .output-frame {
-        overflow: auto;
         border-left: 0.1em solid #60646838;
+        display: grid;
+        grid-template-areas:
+            'actions'
+            'output';
+        grid-template-columns: 1fr;
+        grid-template-rows: auto 1fr;
+
+        #code-buttons {
+            grid-area: actions;
+            border-bottom: 0.1em solid #60646838;
+            margin: 0;
+            padding: 0.2em;
+        }
+
+        .output-lines {
+            grid-area: output;
+        }
     }
 
     .output {

--- a/site/styles.css
+++ b/site/styles.css
@@ -1585,7 +1585,7 @@ a.clean {
     cursor: help;
 }
 
-@media (max-width: 640) {
+@media (max-width: 640px) {
     .expand-editor-button {
         display: none;
     }

--- a/site/styles.css
+++ b/site/styles.css
@@ -419,9 +419,10 @@ li {
 }
 
 #settings {
+    grid-area: settings;
     display: flex;
     justify-content: space-between;
-    font-size: 0.82em;
+    font-size: 0.6em;
     padding: 0.2em;
     gap: 0.5em;
 }
@@ -473,7 +474,9 @@ option,
 }
 
 #code-area {
+    grid-area: editor;
     position: relative;
+    overflow: auto;
 }
 
 .code-outer {
@@ -488,8 +491,6 @@ option,
     min-height: 1.8em;
     display: flex;
     gap: 0.1em;
-    overflow-x: auto;
-    overflow-y: hidden;
 }
 
 .code-and-overlay {
@@ -540,7 +541,7 @@ option,
 }
 
 .line-numbers {
-    min-width: 1.5em;
+    min-width: 2em;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -589,6 +590,8 @@ option,
     display: flex;
     justify-content: space-between;
     min-height: 1.9em;
+    overflow-x: hidden;
+    grid-area: output;
 }
 
 .output-lines {
@@ -795,11 +798,11 @@ option,
 
 .glyph-buttons {
     padding: 0.1em;
-    font-size: 1.4em;
     display: flex;
     flex-wrap: wrap;
     justify-content: space-evenly;
     align-items: baseline;
+    grid-area: glyphs;
 }
 
 .glyph-button {
@@ -1519,6 +1522,7 @@ a.clean {
     flex-direction: row;
     flex-wrap: wrap;
     gap: 0.3em;
+    grid-area: files;
 
     @media (prefers-color-scheme: light) {
         border-color: #0000001a;
@@ -1532,7 +1536,7 @@ a.clean {
     background-color: #294259;
     border-radius: 999px;
     cursor: pointer;
-    font-size: .75em;
+    font-size: .6em;
     line-height: 1em;
 
     @media (prefers-color-scheme: light) {
@@ -1553,4 +1557,77 @@ a.clean {
     text-decoration: underline dotted;
     font-size: 0.8em;
     cursor: help;
+}
+
+.normal-editor {
+    display: grid;
+    grid-template-areas:
+        'glyphs'
+        'files'
+        'settings'
+        'editor'
+        'output'
+        ;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto 1fr auto;
+}
+
+.fullscreen-editor {
+    display: grid;
+    grid-template-areas:
+        'glyphs output'
+        'files output'
+        'settings output'
+        'editor output'
+        ;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto auto 1fr;
+
+    border-radius: 0 !important;
+    outline: none;
+
+    position: fixed !important;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 999;
+
+    .code-outer {
+        resize: none;
+        height: 100% !important;
+        border-bottom-right-radius: 0;
+        border-bottom-right-radius: 0;
+        overflow-y: unset;
+        overflow-x: unset;
+    }
+
+    .code-entry {
+        height: 100% !important;
+    }
+
+    .output-lines {
+        width: 100%;
+        overflow-x: unset;
+    }
+
+    .output-wrapper {
+        transform: none;
+        overflow-x: unset;
+    }
+
+    .output-frame {
+        overflow: auto;
+        border-left: 0.1em solid #60646838;
+    }
+
+    .output {
+        transform: none;
+        margin: 0;
+        padding: 0.4em;
+    }
+
+    .output-diagnostics {
+        margin: 0;
+        padding: 0.4em;
+    }
 }

--- a/site/styles.css
+++ b/site/styles.css
@@ -393,6 +393,24 @@ li {
 .editor {
     border-radius: 0.5em;
     position: relative;
+
+    ::-webkit-scrollbar {
+        width: 5px;
+        height: 5px;
+    }
+
+    ::-webkit-scrollbar-track {
+        -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    }
+
+    ::-webkit-scrollbar-thumb {
+        background: rgba(255, 255, 255, 0.3);
+        -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5);
+    }
+
+    ::-webkit-scrollbar-thumb:window-inactive {
+        background: rgba(255, 255, 255, 0.3);
+    }
 }
 
 #drag-message {
@@ -735,7 +753,6 @@ option,
     top: 0.5em;
     right: 0.2em;
     padding-right: 0.3em;
-    font-size: min(1em, 3vw);
     align-items: center;
     gap: 0.25em;
     z-index: 2;
@@ -1566,6 +1583,12 @@ a.clean {
     text-decoration: underline dotted;
     font-size: 0.8em;
     cursor: help;
+}
+
+@media (max-width: 640) {
+    .expand-editor-button {
+        display: none;
+    }
 }
 
 .draggable-splitter {

--- a/site/styles.css
+++ b/site/styles.css
@@ -498,7 +498,7 @@ option,
 }
 
 .code-entry {
-    margin: 0.1em 0 0 0;
+    margin: 0;
     padding: 0;
     position: absolute;
     outline: none;
@@ -724,30 +724,29 @@ option,
 #code-right-side {
     display: flex;
     position: absolute;
-    top: 0.1em;
+    top: 0.5em;
     right: 0.2em;
     padding-right: 0.3em;
     font-size: min(1em, 3vw);
     align-items: center;
-}
-
-#glyphs-toggle-button {
-    font-weight: bolder;
-    font-size: 0.9em;
-}
-
-#glyphs-toggle-button:hover:after {
-    font-size: 0.6em;
+    gap: 0.25em;
 }
 
 .editor-right-button {
-    font-weight: bolder;
+    font-size: 0.75em;
+    width: 1em;
+    height: 1em;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 0.25em;
     opacity: 0.5;
+    padding: 0.75em;
+    transition: .25s;
 }
 
 .editor-right-button:hover {
     opacity: 1;
-    z-index: 2;
 }
 
 .info-button:hover::after,
@@ -756,13 +755,15 @@ option,
     content: attr(data-title);
     position: absolute;
     font-family: "Code Font", monospace;
-    font-size: 1em;
-    left: calc(-8em - 50%);
+    font-size: 0.75em;
+    right: 0;
+    top: 100%;
     bottom: 1.5em;
     color: #eee;
     padding: 0.2em;
     border-radius: 0.2em;
     pointer-events: none;
+    height: fit-content;
 }
 
 .editor-right-button:hover::after,


### PR DESCRIPTION
This change implements an alternative pad layout and other miscellaneous improvements to the pad.

Alternative layout changes:
- Added a button to the top-right text editor element actions. The button is not visible on mobile, because the new layout is only optimized for desktop at the moment. The button is only visible in the pad page.
- Clicking the button expands the editor to take up the whole screen, placing the editor (including glyph buttons, virtual file system and settings) to the left and the output to the right.
- The column separator is draggable to allow adjusting how much of the editor you want to see versus how much of the output you want to see.
- These changes modify the editor's DOM structure quite a bit, now both the normal and the expanded editors use a grid layout instead of flex. Some changes were also required to make scrolling the editor text and output work as expected in the new layout.

![image](https://github.com/user-attachments/assets/1d1cd30e-3e98-4f89-ad01-dda62f125306)

Misc changes:
- The text input was not properly aligned with overlay, this has been fixed. Before this, the text area was slightly lower than the visible text which made the text cursor and selection not quite line up with the text overlay.
- The icons in the top-right of the text editor element have been replaced with Material icons. Before this, it was using emojis and various Unicode characters that did not look consistent next to each other.
- Changed the editor scrollbars to appear thinner on webkit/chromum browsers. The thick default scrollbars mess with aesthetics with the rest of the editor. This does not affect Firefox based browsers, but they already use a similar style.

I tested the changes on Chrome and Firefox with both light and dark mode, seems to work and look the same.

