### PR TITLE
Various pad fixes and improvements

### DIFF
--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -1673,8 +1673,8 @@ pub fn Editor<'a>(
                 view! {
                     <div class="pad-file-tab" on:click=on_insert>
                         {&path_clone.to_string_lossy().into_owned()}
-                        <span class="pad-file-tab-button" on:click=on_download inner_html="🠻" />
-                        <span class="pad-file-tab-button" on:click=on_delete inner_html="&times;" />
+                        <span class="material-symbols-rounded pad-file-tab-button" on:click=on_download>download</span>
+                        <span class="material-symbols-rounded pad-file-tab-button" on:click=on_delete>delete</span>
                     </div>
                 }
             })

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -90,6 +90,7 @@ pub fn Editor<'a>(
 
     let editor_wrapper_id = move || format!("editor{id}");
     let code_id = move || format!("code{id}");
+    let code_area_id = move || format!("code-area{id}");
     let code_outer_id = move || format!("code-outer{id}");
     let overlay_id = move || format!("overlay{id}");
     let glyph_doc_id = move || format!("glyphdoc{id}");
@@ -98,8 +99,6 @@ pub fn Editor<'a>(
 
     let editor_wrapper_element = move || -> HtmlDivElement { element(&editor_wrapper_id()) };
     let code_element = move || -> HtmlTextAreaElement { element(&code_id()) };
-    #[allow(unused)]
-    let code_outer_element = move || -> HtmlDivElement { element(&code_outer_id()) };
     let glyph_doc_element = move || -> HtmlDivElement { element(&glyph_doc_id()) };
 
     // Track line count
@@ -135,6 +134,7 @@ pub fn Editor<'a>(
     // Initialize the state
     let state = State {
         code_id: code_id(),
+        code_area_id: code_area_id(),
         code_outer_id: code_outer_id(),
         set_overlay,
         set_line_count,
@@ -1928,11 +1928,10 @@ pub fn Editor<'a>(
                         {example_tracker_element}
                     </div>
 
-                    <div id="code-area">
+                    <div id=code_area_id class="code-area" style=format!("height: {}em;", code_height_em + 1.25 / 2.0)>
                         <div
                             id=code_outer_id
                             class="code code-outer sized-code"
-                            style=format!("height: {}em;", code_height_em + 1.25 / 2.0)
                         >
                             <div class="line-numbers">{line_numbers}</div>
                             <div class="code-and-overlay">

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -1673,8 +1673,18 @@ pub fn Editor<'a>(
                 view! {
                     <div class="pad-file-tab" on:click=on_insert>
                         {&path_clone.to_string_lossy().into_owned()}
-                        <span class="material-symbols-rounded pad-file-tab-button" on:click=on_download>download</span>
-                        <span class="material-symbols-rounded pad-file-tab-button" on:click=on_delete>delete</span>
+                        <span
+                            class="material-symbols-rounded pad-file-tab-button"
+                            on:click=on_download
+                        >
+                            download
+                        </span>
+                        <span
+                            class="material-symbols-rounded pad-file-tab-button"
+                            on:click=on_delete
+                        >
+                            delete
+                        </span>
                     </div>
                 }
             })
@@ -1932,12 +1942,15 @@ pub fn Editor<'a>(
                         {example_tracker_element}
                     </div>
 
-                    <div id=code_area_id class="code-area" style=format!("height: {}em;", code_height_em + 1.25 / 2.0)>
-                        <div
-                            id=code_outer_id
-                            class="code code-outer sized-code"
-                        >
-                            <div id=line_numbers_id class="line-numbers">{line_numbers}</div>
+                    <div
+                        id=code_area_id
+                        class="code-area"
+                        style=format!("height: {}em;", code_height_em + 1.25 / 2.0)
+                    >
+                        <div id=code_outer_id class="code code-outer sized-code">
+                            <div id=line_numbers_id class="line-numbers">
+                                {line_numbers}
+                            </div>
                             <div class="code-and-overlay">
                                 // ///////////////////////
                                 // The text entry area //

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -92,6 +92,7 @@ pub fn Editor<'a>(
     let code_id = move || format!("code{id}");
     let code_area_id = move || format!("code-area{id}");
     let code_outer_id = move || format!("code-outer{id}");
+    let line_numbers_id = move || format!("line-numbers{id}");
     let overlay_id = move || format!("overlay{id}");
     let glyph_doc_id = move || format!("glyphdoc{id}");
     let hover_id = move || format!("hover{id}");
@@ -136,6 +137,8 @@ pub fn Editor<'a>(
         code_id: code_id(),
         code_area_id: code_area_id(),
         code_outer_id: code_outer_id(),
+        line_numbers_id: line_numbers_id(),
+        editor_wrapper_id: editor_wrapper_id(),
         set_overlay,
         set_line_count,
         set_copied_link,
@@ -256,6 +259,7 @@ pub fn Editor<'a>(
     let run = move |do_format: bool, set_cursor: bool| {
         // Format code
         let (input, seed) = format(do_format, set_cursor);
+        state.update(|s| s.update_line_number_width());
 
         // Run code
         set_output.set(view! { <div class="running-text">"Running"</div> }.into_view());
@@ -1933,7 +1937,7 @@ pub fn Editor<'a>(
                             id=code_outer_id
                             class="code code-outer sized-code"
                         >
-                            <div class="line-numbers">{line_numbers}</div>
+                            <div id=line_numbers_id class="line-numbers">{line_numbers}</div>
                             <div class="code-and-overlay">
                                 // ///////////////////////
                                 // The text entry area //

--- a/pad/editor/src/utils.rs
+++ b/pad/editor/src/utils.rs
@@ -47,6 +47,8 @@ pub struct State {
     pub code_id: String,
     pub code_area_id: String,
     pub code_outer_id: String,
+    pub line_numbers_id: String,
+    pub editor_wrapper_id: String,
     pub set_overlay: WriteSignal<String>,
     pub set_line_count: WriteSignal<usize>,
     pub set_copied_link: WriteSignal<bool>,
@@ -146,7 +148,10 @@ impl State {
         let outer = element::<HtmlDivElement>(&self.code_outer_id);
 
         let height = format!("{}em", code.split('\n').count().max(1) as f32 * 1.25 + 0.75);
-        code_area.style().set_property("--normal-min-height", &height).unwrap();
+        code_area
+            .style()
+            .set_property("--normal-min-height", &height)
+            .unwrap();
 
         let rect = &virtual_rect(&area, code);
         let width = rect.width();
@@ -201,9 +206,25 @@ impl State {
         self.set_copied_link.set(false);
         self.set_line_count();
     }
-    fn set_line_count(&self) {
+    pub fn update_line_number_width(&self) {
+        let line_numbers = element::<HtmlDivElement>(&self.line_numbers_id);
+        let editor = element::<HtmlDivElement>(&self.editor_wrapper_id);
+        let line_numbers_width = line_numbers.get_bounding_client_rect().width();
+        let line_numbers_width_str = format!("{}px", line_numbers_width);
+        editor
+            .style()
+            .set_property("--line-numbers-width", &line_numbers_width_str)
+            .unwrap();
+    }
+    pub fn set_line_count(&self) {
         self.set_line_count
             .set(get_code(&self.code_id).split('\n').count().max(1));
+
+        let state = self.clone();
+        set_timeout(
+            move || state.update_line_number_width(),
+            Duration::from_millis(0),
+        );
     }
     pub fn clear_history(&mut self) {
         self.past.clear();

--- a/pad/editor/src/utils.rs
+++ b/pad/editor/src/utils.rs
@@ -45,6 +45,7 @@ pub struct ChallengeDef {
 #[derive(Clone)]
 pub struct State {
     pub code_id: String,
+    pub code_area_id: String,
     pub code_outer_id: String,
     pub set_overlay: WriteSignal<String>,
     pub set_line_count: WriteSignal<usize>,
@@ -141,10 +142,11 @@ impl State {
         }
         self.set_overlay.set(code.into());
         let area = element::<HtmlTextAreaElement>(&self.code_id);
+        let code_area = element::<HtmlDivElement>(&self.code_area_id);
         let outer = element::<HtmlDivElement>(&self.code_outer_id);
 
         let height = format!("{}em", code.split('\n').count().max(1) as f32 * 1.25 + 0.75);
-        outer.style().set_property("min-height", &height).unwrap();
+        code_area.style().set_property("--normal-min-height", &height).unwrap();
 
         let rect = &virtual_rect(&area, code);
         let width = rect.width();

--- a/site/styles.css
+++ b/site/styles.css
@@ -1569,7 +1569,7 @@ a.clean {
 
 .pad-file-tab-button {
     opacity: 0.5;
-    scale: 1.2;
+    font-size: 1em;
 
     &:hover {
         opacity: 1;

--- a/site/styles.css
+++ b/site/styles.css
@@ -494,7 +494,6 @@ option,
 .editor-area {
     grid-area: editor;
     position: relative;
-    overflow: hidden;
 }
 
 #code-area {
@@ -1692,5 +1691,9 @@ a.clean {
 
     .draggable-splitter {
         display: block;
+    }
+
+    .editor-area {
+        overflow: hidden;
     }
 }

--- a/site/styles.css
+++ b/site/styles.css
@@ -496,21 +496,19 @@ option,
     position: relative;
 }
 
-#code-area {
+.code-area {
     overflow: auto;
-    height: 100%;
 }
 
 .code-outer {
     text-align: left;
     border-radius: 0.5em;
     width: 100%;
-    resize: vertical;
     box-sizing: border-box;
     outline: none;
     border: none;
     padding: 0.3em;
-    min-height: 1.8em;
+    height: 100%;
     display: flex;
     gap: 0.1em;
 }
@@ -1613,6 +1611,11 @@ a.clean {
     ;
     grid-template-columns: 1fr;
     grid-template-rows: auto auto auto 1fr auto;
+
+    .code-area {
+        min-height: var(--normal-min-height);
+        resize: vertical;
+    }
 }
 
 .fullscreen-editor {
@@ -1637,11 +1640,16 @@ a.clean {
 
     .code-outer {
         resize: none;
-        height: 100% !important;
-        border-bottom-right-radius: 0;
+        min-height: 100%;
+        height: fit-content;
+        border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
         overflow-y: unset;
         overflow-x: unset;
+    }
+
+    .code-area {
+        height: 100% !important;
     }
 
     .code-entry {

--- a/site/styles.css
+++ b/site/styles.css
@@ -510,7 +510,7 @@ option,
     padding: 0.3em;
     height: 100%;
     display: flex;
-    gap: 0.1em;
+    gap: 0.5em;
 }
 
 .code-and-overlay {
@@ -561,7 +561,7 @@ option,
 }
 
 .line-numbers {
-    min-width: 2em;
+    text-align: right;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -1612,9 +1612,15 @@ a.clean {
     grid-template-columns: 1fr;
     grid-template-rows: auto auto auto 1fr auto;
 
+    --line-numbers-width: 0;
+
     .code-area {
         min-height: var(--normal-min-height);
         resize: vertical;
+    }
+
+    .output {
+        margin-left: max(calc(var(--line-numbers-width) + 0.8em), 1.45em);
     }
 }
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -634,7 +634,7 @@ option,
 .output {
     white-space: pre;
     text-align: left;
-    margin-left: 1.85em;
+    margin-left: 2.3em;
     padding: 0.4em 0;
     font-family: "Code Font", monospace;
     transform: rotateX(180deg);


### PR DESCRIPTION
This PR focuses on fixing minor issues introduced in previous PR and further improving the pad in small ways:
- Fixes an issue where icon hover hints were cut off for small editors in documentation.
- Fixes a regression where you couldn't resize the normal editor.
- Implemented adaptive line number column width. Output of the normal editor dynamically lines up with the source code according to the width of the line numbers.
- Implemented a change to align line numbers to the right, like most other editors.
- Changed virtual file system tabs to use Material icons.