### PR TITLE
Do not add an extra space to enum data definitions when formatting code

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -724,9 +724,9 @@ impl Formatter<'_> {
                 self.push(&data.init_span, if data.variant { "|" } else { "~" });
                 if let Some(name) = &data.name {
                     self.push(&name.span, &name.value);
-                    self.output.push(' ');
                 }
                 if let Some(fields) = &data.fields {
+                    self.output.push(' ');
                     self.push(&fields.open_span, if fields.boxed { "{" } else { "[" });
                     let multiline = fields.trailing_newline
                         || fields.fields.len() > 1


### PR DESCRIPTION
This fixes a small issue with formatting enum data definitions. Currently, if the enum variant definition does not have data - an extra space character is added to the end of it. This change makes it so the extra space only gets added when the data definition has some data.

Currently (the ␣ is a space):
```uiua
┌─╴Foo
␣␣|Bar␣
␣␣|Baz␣[Quix]
└─╴
```

After the change:
```uiua
┌─╴Foo
␣␣|Bar 
␣␣|Baz␣[Quix]
└─╴
```