### PR TITLE
fix negative hues not working as expected

### DIFF
--- a/src/algorithm/monadic/mod.rs
+++ b/src/algorithm/monadic/mod.rs
@@ -2020,12 +2020,12 @@ impl Array<f64> {
                 unreachable!();
             };
             let h = h / TAU * 6.0;
-            let i = h.floor() as usize;
+            let i = h.floor() as isize;
             let f = h - i as f64;
             let p = v * (1.0 - s);
             let q = v * (1.0 - f * s);
             let t = v * (1.0 - (1.0 - f) * s);
-            let (r, g, b) = match i % 6 {
+            let (r, g, b) = match i.rem_euclid(6) {
                 0 => (v, t, p),
                 1 => (q, v, p),
                 2 => (p, v, t),


### PR DESCRIPTION
casting to usize messed up the sign, casting to isize + using modulus instead of remainder fixed it