### PR TITLE
add see also links between minimum and maximum

### DIFF
--- a/src/primitive/defs.rs
+++ b/src/primitive/defs.rs
@@ -455,6 +455,8 @@ primitive!(
     /// ex: ↧ [1 4 2] [3 7 1]
     /// Boxes compare lexicographically
     /// ex: ↧ {1_2_3 "dog"} {1_4_5 "cat"}
+    ///
+    /// See also: [maximum]
     (2, Min, DyadicPervasive, ("minimum", '↧')),
     /// Take the maximum of two arrays
     ///
@@ -466,6 +468,8 @@ primitive!(
     /// Uiua does not have dedicated boolean logical operators.
     /// [maximum] can be used as a logical OR.
     /// ex: ◡↥≤5:≥8. [6 2 5 9 6 5 0 4]
+    ///
+    /// See also: [minimum]
     (2, Max, DyadicPervasive, ("maximum", '↥')),
     /// Take the arctangent of two numbers
     ///


### PR DESCRIPTION
Hi

This small addition to the doc eases cross-references between `minimum` and `maximum` (like it's already the case between `first` and `last` for example…)

Thanks for this great project!