### PR TITLE
add alias "dnod" for drop negate on drop

### DIFF
--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -636,6 +636,7 @@ impl Primitive {
             ("kbn", &[(Keep, "k"), (By, "b"), (Ne, "n")]),
             ("ftd", &[(Fork, "f"), (Take, "t"), (Drop, "d")]),
             ("fdt", &[(Fork, "f"), (Drop, "d"), (Take, "t")]),
+	    ("dnod", &[(Drop, "d"), (Neg, "n"), (On, "o"), (Drop, "d")]),
             (
                 "adnoad",
                 &[

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -636,7 +636,7 @@ impl Primitive {
             ("kbn", &[(Keep, "k"), (By, "b"), (Ne, "n")]),
             ("ftd", &[(Fork, "f"), (Take, "t"), (Drop, "d")]),
             ("fdt", &[(Fork, "f"), (Drop, "d"), (Take, "t")]),
-	        ("dnod", &[(Drop, "d"), (Neg, "n"), (On, "o"), (Drop, "d")]),
+            ("dnod", &[(Drop, "d"), (Neg, "n"), (On, "o"), (Drop, "d")]),
             (
                 "adnoad",
                 &[

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -636,7 +636,7 @@ impl Primitive {
             ("kbn", &[(Keep, "k"), (By, "b"), (Ne, "n")]),
             ("ftd", &[(Fork, "f"), (Take, "t"), (Drop, "d")]),
             ("fdt", &[(Fork, "f"), (Drop, "d"), (Take, "t")]),
-	    ("dnod", &[(Drop, "d"), (Neg, "n"), (On, "o"), (Drop, "d")]),
+	        ("dnod", &[(Drop, "d"), (Neg, "n"), (On, "o"), (Drop, "d")]),
             (
                 "adnoad",
                 &[


### PR DESCRIPTION
Since `adnoad` was added for padding on both sides, it makes sense that the opposite operation of dropping on both sides should have an alias too.