### PR TITLE
remove .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake


### PR DESCRIPTION
The .envrc is needed for setting up local environment automatically. Naturally, different developers have different needs. With .envrc being tracked, not only a certain configuration is forced, it is also not possible to override this configuration. Ideally, .envrc should be placed in the user's global gitignore, if they wish to use direnv.

See direnv/direnv#556 for more motivation and complaints.