### PR TITLE
Fix bug with under fork

### DIFF
--- a/tests/under.ua
+++ b/tests/under.ua
@@ -406,6 +406,7 @@ G ← ⍜(⊙⊙⊢) ⋅⊙∘
 
 # Under/unby fork
 ⍤⤙≍ "wham" ⍜⊃⊢⊣⊓(+3|-7) "that"
+⍤⤙≍ "wham" ⍜⊃⊢⊣⋅◌ "that" @w @m
 ⍤⤙≍ "wham" °⊸⊃⊢⊣ @w @m "that"
 ⍤⤙≍ "THESE THOSE" °⊸⊃±◴ 1 "thes o" "abcdceabfdc"
 


### PR DESCRIPTION
My original implementation of under fork would break if under's second function touched anything beneath the outputs of the first function on the stack. This fixes that issue.