### PR TITLE
Add assert for sizeof(usize)>=sizeof(u32)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,13 @@ fn is_default<T: Default + PartialEq>(v: &T) -> bool {
     v == &T::default()
 }
 
+const _: () = {
+    assert!(
+        size_of::<usize>() >= size_of::<u32>(),
+        "Code requires that word size be at least four bytes"
+    );
+};
+
 #[cfg(test)]
 mod tests {
     use std::path::*;


### PR DESCRIPTION
Many parts of the code rely on this hidden assumption, this makes it concrete at compile time