### PR TITLE
Tweak ordering of changelog entries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,8 +23,8 @@ This version is not yet released. If you are reading this on the website, then t
 - Add experimental sided subscripts for [`backward ˜`](https://uiua.org/docs/backward)
 - Add numeric subscripts for [`occurrences ⧆`](https://uiua.org/docs/occurrences)
 - Deprecate experimental [`progressive indexof ⊘`](https://uiua.org/docs/progressiveindexof) in favor of [`occurrences ⧆`](https://uiua.org/docs/occurrences)
-- Deprecate [`logarithm ₙ`](https://uiua.org/docs/logarithm) in favor of [`exponential ₑ`](https://uiua.org/docs/exponential)
 - Add the [`exponential ₑ`](https://uiua.org/docs/exponential) function, which computes the exponential function
+- Deprecate [`logarithm ₙ`](https://uiua.org/docs/logarithm) in favor of [`exponential ₑ`](https://uiua.org/docs/exponential)
 - Remove experimental `ln` in favor of [`exponential ₑ`](https://uiua.org/docs/exponential)
 - Remove previously deprecated `signature` and `stringify` modifiers
 ### Interpreter


### PR DESCRIPTION
The bullet point for adding `exponential` should come before both bullets for removing things in favor of it.
