### PR TITLE
make removing # Experimental! easier

### DIFF
--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -484,8 +484,7 @@ pub fn Editor<'a>(
                     Cursor::Ignore
                 };
                 state.set_code(new_code, cursor);
-            }
-            else if code == "# Experimental!" {
+            } else if code == "# Experimental!" {
                 state.set_code("", Cursor::Set(0, 0));
             }
         });
@@ -1021,8 +1020,7 @@ pub fn Editor<'a>(
         let code = get_code();
         if code.starts_with("# Experimental!\n") || code == "# Experimental!" {
             remove_experimental();
-        }
-        else {
+        } else {
             insert_experimental();
         }
     };

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -1017,12 +1017,20 @@ pub fn Editor<'a>(
         }
     };
 
-    let on_insert_experimental = move |_| insert_experimental();
-    let add_experimental_button = view! {
+    let on_toggle_experimental = move |_| {
+        let code = get_code();
+        if code.starts_with("# Experimental!\n") || code == "# Experimental!" {
+            remove_experimental();
+        }
+        else {
+            insert_experimental();
+        }
+    };
+    let toggle_experimental_button = view! {
         <button
             class="info-button"
-            data-title="Add # Experimental"
-            on:click=on_insert_experimental
+            data-title="Toggle # Experimental"
+            on:click=on_toggle_experimental
         >
             "🧪"
         </button>
@@ -1107,7 +1115,7 @@ pub fn Editor<'a>(
         EditorMode::Showcase | EditorMode::Pad => true,
     });
 
-    let glyph_add_experimental_button = add_experimental_button.clone();
+    let glyph_toggle_experimental_button = toggle_experimental_button.clone();
 
     let glyph_buttons_container = move || {
         show_glyphs.get().then(|| {
@@ -1308,7 +1316,7 @@ pub fn Editor<'a>(
                 .into_view(),
             );
 
-            let experimental_glyph_buttons: Vec<_> = once(glyph_add_experimental_button.clone())
+            let experimental_glyph_buttons: Vec<_> = once(glyph_toggle_experimental_button.clone())
                 .chain(
                     Primitive::non_deprecated()
                         .filter(|prim| prim.is_experimental())
@@ -1969,7 +1977,7 @@ pub fn Editor<'a>(
                     </div>
                     <div id="settings-right">
                         <div style="display: flex; gap: 0.2em;">
-                            {add_experimental_button}
+                            {toggle_experimental_button}
                             <button class="info-button" data-title=EDITOR_SHORTCUTS disabled>
                                 "🛈"
                             </button>

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -1027,7 +1027,7 @@ pub fn Editor<'a>(
     let toggle_experimental_button = view! {
         <button
             class="info-button"
-            data-title="Toggle # Experimental"
+            data-title="Toggle # Experimental!"
             on:click=on_toggle_experimental
         >
             "🧪"

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -477,6 +477,24 @@ pub fn Editor<'a>(
         });
     };
 
+    // Remove an # Experimental! comment from the top of the code
+    let remove_experimental = move || {
+        state.update(|state| {
+            let code = get_code();
+            if let Some(new_code) = code.strip_prefix("# Experimental!\n") {
+                let cursor = if let Some((start, end)) = get_code_cursor() {
+                    Cursor::Set(start.saturating_sub(16), end.saturating_sub(16))
+                } else {
+                    Cursor::Ignore
+                };
+                state.set_code(new_code, cursor);
+            }
+            else if code == "# Experimental!" {
+                state.set_code("", Cursor::Set(0, 0));
+            }
+        });
+    };
+
     // Handle key events
     window_event_listener(mousemove, move |event| {
         if let Some(overlay_element) = get_element::<HtmlDivElement>(&overlay_id()) {
@@ -744,6 +762,8 @@ pub fn Editor<'a>(
             "z" if os_ctrl(event) => state.update(|state| state.undo()),
             // Insert # Experimental! comment
             "e" if os_ctrl(event) => insert_experimental(),
+            // Remove # Experimental! comment
+            "E" if os_ctrl(event) => remove_experimental(),
             // Toggle line comment
             "/" | "4" if os_ctrl(event) => {
                 state.update(|state| {

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -755,10 +755,10 @@ pub fn Editor<'a>(
             "z" | "Z" if os_ctrl(event) && event.shift_key() => state.update(|state| state.redo()),
             // Undo
             "z" if os_ctrl(event) => state.update(|state| state.undo()),
+            // Remove # Experimental! comment
+            "e" | "E" if os_ctrl(event) && event.shift_key() => remove_experimental(),
             // Insert # Experimental! comment
             "e" if os_ctrl(event) => insert_experimental(),
-            // Remove # Experimental! comment
-            "E" if os_ctrl(event) => remove_experimental(),
             // Toggle line comment
             "/" | "4" if os_ctrl(event) => {
                 state.update(|state| {

--- a/pad/editor/src/lib.rs
+++ b/pad/editor/src/lib.rs
@@ -460,16 +460,12 @@ pub fn Editor<'a>(
     let insert_experimental = move || {
         state.update(|state| {
             let code = get_code();
-            if code.starts_with("# Experimental!") {
+            if code.starts_with("# Experimental!\n") || code == "# Experimental!" {
                 return;
             }
             let new_code = format!("# Experimental!\n{}", code);
             let cursor = if let Some((start, end)) = get_code_cursor() {
-                if start == 0 {
-                    Cursor::Set(16, 16)
-                } else {
-                    Cursor::Set(start + 16, end + 16)
-                }
+                Cursor::Set(start + 16, end + 16)
             } else {
                 Cursor::Ignore
             };
@@ -2385,7 +2381,8 @@ ctrl/⌘ 4       - Toggle multiline string
  shift Delete  - Delete lines
 ctrl/⌘ Z       - Undo
 ctrl/⌘ Y       - Redo
-ctrl/⌘ E       - Insert # Experimental! comment";
+ctrl/⌘ E       - Insert # Experimental! comment
+ctrl/⌘ shift E - Remove # Experimental! comment";
 
 pub fn replace_lang_name() -> bool {
     cfg!(target_arch = "wasm32") && its_called_weewuh()


### PR DESCRIPTION
- Add the shortcut ctrl+shift+E
- Make the 🧪 button remove experimental comment if it's there
- Make ctrl+E (and 🧪) more consistent