### PR TITLE
fix returned handle when calling &tcpa on a tls listener

### DIFF
--- a/src/sys/native.rs
+++ b/src/sys/native.rs
@@ -888,8 +888,8 @@ impl SysBackend for NativeSys {
                             conn: parking_lot::Mutex::new(TslConnection::Server(conn)),
                         },
                     );
+                    return Ok(handle);
                 }
-                return Ok(handle);
             }
             #[allow(unreachable_code)]
             Err("Invalid tcp listener handle".to_string())


### PR DESCRIPTION
I was working with TLS listeners and the program would sometimes crash when setting the read timeout. This was only after I closed a connection. I noticed the handle to the listener and connection were the same number, and found that the returned handle is the one from the listener, not the newly created stream handle. This was just due to a small scoping issue. I have tested the change alongside [this change](https://github.com/uiua-lang/uiua/compare/main...donstenzel:uiua:tls-handshake) in a website server and it works correctly now.