### PR TITLE
feat: complete handshake using rustls when calling &tcpa on a tls listener

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@ This version is not yet released. If you are reading this on the website, then t
 - Remove the `ⁿ%:1` ("root" pattern) optimization, it undered incorrectly, and should be replaced with [`anti ⌝`](https://uiua.org/docs/anti)[`pow ⁿ`](https://uiua.org/docs/power)
 - Add [`&seek`](https://uiua.org/docs/&seek) function for working with large files
 - Remove previously deprecated `signature` and `stringify` modifiers
+- Calling [`&tcpa`](https://uius.org/docs/&tcpa) on a TLS listener created with [`&tlsl`](https://uiua.org/docs/&tlsl) now automatically tries conducting a TSL handshake
 ### Interpreter
 - The fomatter no longer truncates trailing decimal `0`s from number literals
 - Implement filled adjacent [`stencil ⧈`](https://uiua.org/docs/stencil)

--- a/src/sys/native.rs
+++ b/src/sys/native.rs
@@ -876,9 +876,10 @@ impl SysBackend for NativeSys {
             #[cfg(feature = "tls")]
             {
                 if let Some(listener) = NATIVE_SYS.tls_listeners.get_mut(&handle) {
-                    let (stream, _) = listener.listener.accept().map_err(|e| e.to_string())?;
-                    let conn = rustls::ServerConnection::new(listener.config.clone())
+                    let (mut stream, _) = listener.listener.accept().map_err(|e| e.to_string())?;
+                    let mut conn = rustls::ServerConnection::new(listener.config.clone())
                         .map_err(|e| e.to_string())?;
+                    let _ = conn.complete_io(&mut stream).map_err(|e| e.to_string())?;
                     let handle = NATIVE_SYS.new_handle();
                     NATIVE_SYS.tls_sockets.insert(
                         handle,


### PR DESCRIPTION
Using TLS requires the participants to complete a handshake. This functionality is available in `rustls`, and it almost never makes sense to not complete the handshake. As Uiua wants to offer a higher level API, I think automatically conducting the handshake when accepting a connection makes a lot of sense. Implementing this on the user side would require using a library like OpenSSL w/ FFI and side-stepping `&tlsl` entirely. I tested this change using a website server.