### PR TITLE
fix: fork and fix in planet notation shorthand

### DIFF
--- a/parser/src/split.rs
+++ b/parser/src/split.rs
@@ -263,40 +263,21 @@ pub fn split_name(name: &str) -> Option<Vec<(PrimComponent, &str)>> {
                 continue;
             }
             // 1-letter planet notation
-            if sub_name
-                .strip_prefix('f')
-                .unwrap_or(sub_name)
-                .strip_suffix(['i', 'p'])
-                .unwrap_or(sub_name)
+            let unforked = sub_name.strip_prefix('f').unwrap_or(sub_name);
+            if unforked
+                .strip_suffix(['i', 'p', 'f'])
+                .unwrap_or(unforked)
                 .chars()
                 .all(|c| "gd".contains(c))
-                && sub_name != "fi"
             {
                 for (i, c) in sub_name.char_indices() {
                     let prim = match c {
-                        'f' => Primitive::Fork,
+                        'f' if i == 0 => Primitive::Fork,
+                        'f' => Primitive::Fix,
                         'g' => Primitive::Gap,
                         'd' => Primitive::Dip,
                         'i' => Primitive::Identity,
                         'p' => Primitive::Pop,
-                        _ => unreachable!(),
-                    };
-                    prims.push((prim.into(), &sub_name[i..i + 1]))
-                }
-                start += len;
-                continue 'outer;
-            }
-            // Dip fix
-            if sub_name
-                .strip_suffix('f')
-                .unwrap_or(sub_name)
-                .chars()
-                .all(|c| c == 'd')
-            {
-                for (i, c) in sub_name.char_indices() {
-                    let prim = match c {
-                        'd' => Primitive::Dip,
-                        'f' => Primitive::Fix,
                         _ => unreachable!(),
                     };
                     prims.push((prim.into(), &sub_name[i..i + 1]))


### PR DESCRIPTION
For some reason, planet notation only worked with strings of following forms:
- `fp`
- `f[gd]+[ip]`
- `[gd]{2,}`
- `d+f`

While the following did not work:
- `fi`
- `f[gd]+`
- `f[gd]*f`
- `[gd]*g[gd]*f`

Although it's a bit harder to describe using just regex — for instance, `ggdf` would parse, but as two juxtaposed shorthands, like `gg df`.

With this change, planet notation is treated as described by [Planet aliases](https://www.uiua.org/docs/idioms#planet-aliases): that is, `f?[gd]*[fip]?` containing at least two characters.