### PR TITLE
feat: glyph and subscripts for `dump`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,9 @@ This version is not yet released. If you are reading this on the website, then t
 - Add [`&seek`](https://uiua.org/docs/&seek) function for working with large files
 - Remove previously deprecated `signature` and `stringify` modifiers
 - Calling [`&tcpa`](https://uius.org/docs/&tcpa) on a TLS listener created with [`&tlsl`](https://uiua.org/docs/&tlsl) now automatically tries conducting a TSL handshake
+- Add a glyph and subscript support to [`dump ‽`](https://uiua.org/docs/dump)
+  - Can be formatted from `?!`
+  - Subscripted version can be formatted from a sequence like `?!???`
 ### Interpreter
 - The fomatter no longer truncates trailing decimal `0`s from number literals
 - Implement filled adjacent [`stencil ⧈`](https://uiua.org/docs/stencil)

--- a/parser/src/defs.rs
+++ b/parser/src/defs.rs
@@ -2914,25 +2914,29 @@ primitive!(
     /// Preprocess and print all stack values without popping them
     ///
     /// [dump][identity] is equivalent to [stack].
-    /// ex: dump∘ 1 2 3
+    /// ex: ‽∘ 1 2 3
     /// This is useful when you want to inspect the current ordering of the stack.
     /// For example, if you are juggling some values on the stack, you can use [dump] to inspect the stack afterwards:
     /// ex: 1 2 3
     ///   : ◡⊙∘˜⊙.
-    ///   : dump∘
+    ///   : ‽∘
     ///   : +×-×+
     /// [dump][shape] is useful if your raw array data isn't worth looking at, but the shapes are.
     /// ex: 2_3_10 17 ↯3_4⇡12
-    ///   : dump△
+    ///   : ‽△
     ///   : ++
     /// ex: ↯¯1_5 ⇡30
     ///   : ⍉.⊃≡(⊟.)(⊞+.).
-    ///   : dump△
+    ///   : ‽△
     ///   : +++∩∩⧻
     /// Errors encountered within [dump]'s function are caught and dumped as strings.
     /// ex: 1_2_3 [] 5_6_7
-    ///   : dump⊢
-    (0(0)[1], Dump, Debug, "dump", Mutating),
+    ///   : ‽⊢
+    /// Subscripted [dump] prints that many values from the stack.
+    /// ex: ‽₂△ ∩₃⇡ 1 2_3 4_5_6
+    /// If you type `?!` followed by `N` `?`s, it will format to [dump] subscripted with `N`.
+    /// ex: ?!??sha bot,3ran 1 2_3 4_5_6 # Try formatting!
+    (0(0)[1], Dump, Debug, ("dump", AsciiToken::Interrobang, '‽'), Mutating),
     /// Convert a string into code at compile time
     ///
     /// ex: # Experimental!

--- a/parser/src/lex.rs
+++ b/parser/src/lex.rs
@@ -773,6 +773,7 @@ pub enum AsciiToken {
     Tilde,
     DoubleTilde,
     Quote,
+    Interrobang,
 }
 
 impl fmt::Display for AsciiToken {
@@ -801,6 +802,7 @@ impl fmt::Display for AsciiToken {
             AsciiToken::Tilde => write!(f, "~"),
             AsciiToken::DoubleTilde => write!(f, "~~"),
             AsciiToken::Quote => write!(f, "'"),
+            AsciiToken::Interrobang => write!(f, "?!"),
         }
     }
 }
@@ -1115,9 +1117,14 @@ impl<'a> Lexer<'a> {
                     self.next_char_exact("~");
                     self.end(CloseModule, start)
                 }
-                // Stack
+                // Stack/Dump
                 "?" => {
-                    self.end(Primitive::Stack, start);
+                    let tok = if self.next_char_exact("!") {
+                        Primitive::Dump
+                    } else {
+                        Primitive::Stack
+                    };
+                    self.end(tok, start);
                     let mut n = 0;
                     let start = self.loc;
                     while self.next_char_exact("?") {

--- a/site/src/primitive.rs
+++ b/site/src/primitive.rs
@@ -273,7 +273,7 @@ fn all_uns() -> impl IntoView {
             { inverse_row([Group], No, "Inner function must be invertible", "°⊕□ {1 2_3_4 5_6}") }
             { inverse_row([Repeat], Required, "Inner function must be invertible", "°(⍥(×2)5) 1024") }
             { inverse_row([Stack], No, "", "°? 5") }
-            { inverse_row([Dump], No, "", "°dump△ [2 3 4]") }
+            { inverse_row([Dump], No, "", "°‽△ [2 3 4]") }
             { inverse_row([Pop], RequiresFill, "", "⬚5°◌") }
             { inverse_row([AudioEncode], Optional, "Decodes bytes", None) }
             { inverse_row([ImageEncode], Optional, "Decodes bytes", None) }

--- a/src/compile/invert/un.rs
+++ b/src/compile/invert/un.rs
@@ -231,6 +231,7 @@ pub static UN_PATTERNS: &[&dyn InvertPattern] = &[
     &RepeatPat,
     &DupPat,
     &DumpPat,
+    &DumpNPat,
     &NBitsPat,
     &(Sqrt, (Dup, Mul)),
     &(Select, (Dup, Len, Range)),
@@ -1092,6 +1093,27 @@ inverse!(DupPat, input, asm, Prim(Dup, dup_span), {
 inverse!(DumpPat, input, _, ref, Mod(Dump, args, span), {
     Ok((input, ImplMod(UnDump, args.clone(), *span)))
 });
+
+inverse!(
+    DumpNPat,
+    input,
+    _,
+    ref,
+    ImplMod(DumpN { n, inverse }, args, span),
+    {
+        Ok((
+            input,
+            ImplMod(
+                DumpN {
+                    n: *n,
+                    inverse: !inverse,
+                },
+                args.clone(),
+                *span,
+            ),
+        ))
+    }
+);
 
 inverse!(AlgebraPat, input, asm, {
     let mut error = Generic;

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -2195,6 +2195,7 @@ impl Compiler {
                             | (Rows | Each | Inventory)
                             | (Repeat | Tuples | Stencil)
                             | (Fill | Geometric)
+                            | Dump
                     ) {
                         self.add_error(
                             m.modifier.span.clone().merge(scr.span.clone()),

--- a/src/compile/modifier.rs
+++ b/src/compile/modifier.rs
@@ -1467,6 +1467,21 @@ impl Compiler {
                 let op = modified.code_operands().next().unwrap().clone();
                 self.geometric(op, subscript, None)?
             }
+            Dump => {
+                let (sn, _) = self.monadic_modifier_op(modified)?;
+                let span = self.add_span(modified.modifier.span.clone());
+                let Some(n) = subscript.and_then(|sub| {
+                    self.subscript_n_only(&sub, prim)
+                        .map(|x| self.positive_subscript(x, prim, &sub.span))
+                }) else {
+                    return Ok(None);
+                };
+                Node::ImplMod(
+                    ImplPrimitive::DumpN { n, inverse: false },
+                    eco_vec![sn],
+                    span,
+                )
+            }
             _ => return Ok(None),
         }))
     }

--- a/src/impl_prim.rs
+++ b/src/impl_prim.rs
@@ -35,6 +35,7 @@ macro_rules! impl_primitive {
             UndoRotate(usize),
             ReduceDepth(usize),
             StackN { n: usize, inverse: bool },
+            DumpN { n: usize, inverse: bool },
             OnSub(usize),
             BySub(usize),
             WithSub(usize),
@@ -59,6 +60,7 @@ macro_rules! impl_primitive {
                     ImplPrimitive::UndoRotate(n) => *n + 1,
                     ImplPrimitive::ReduceDepth(_) => 1,
                     ImplPrimitive::StackN { n, .. } => *n,
+                    ImplPrimitive::DumpN { n, .. } => *n,
                     ImplPrimitive::MaxRowCount(n) => *n,
                     ImplPrimitive::SidedEncodeBytes(_) | ImplPrimitive::DecodeBytes(_) => 2,
                     ImplPrimitive::Ga(op, _) => op.args(),
@@ -72,6 +74,7 @@ macro_rules! impl_primitive {
                     ImplPrimitive::UndoReverse { n, .. } => *n,
                     ImplPrimitive::UndoRotate(n) => *n,
                     ImplPrimitive::StackN { n, .. } => *n,
+                    ImplPrimitive::DumpN { n, .. } => *n,
                     ImplPrimitive::MaxRowCount(n) => *n + 1,
                     ImplPrimitive::SidedEncodeBytes(_) | ImplPrimitive::DecodeBytes(_) => 1,
                     ImplPrimitive::Ga(op, _) => op.outputs(),
@@ -99,6 +102,7 @@ macro_rules! impl_primitive {
                 match self {
                     $($(ImplPrimitive::$variant => {Purity::$purity},)*)*
                     ImplPrimitive::StackN { .. } => Purity::Mutating,
+                    ImplPrimitive::DumpN { .. } => Purity::Mutating,
                     _ => Purity::Pure
                 }
             }
@@ -456,6 +460,15 @@ impl fmt::Display for ImplPrimitive {
                     .map(|c| SUBSCRIPT_DIGITS[(c as u32 as u8 - b'0') as usize])
                     .collect();
                 write!(f, "{Stack}{n_str}")
+            }
+            &DumpN { n, inverse } => {
+                if inverse {
+                    write!(f, "{Un}")?;
+                }
+                let n_str: String = (n.to_string().chars())
+                    .map(|c| SUBSCRIPT_DIGITS[(c as u32 as u8 - b'0') as usize])
+                    .collect();
+                write!(f, "{Dump}{n_str}")
             }
             SidedFill(side) => write!(f, "{Fill}{side}"),
             RepeatWithInverse => write!(f, "{Repeat}"),


### PR DESCRIPTION
Uses `‽`, can be formatted from `?!`. Just like subscripted `stack` can be formatted from a sequence of `?`s, subscripted `dump` can be formatted from `?!` followed by a sequence of `?`s.