### PR TITLE
feat: add support for UDP sockets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,7 +33,12 @@ This version is not yet released. If you are reading this on the website, then t
 - Remove the `ⁿ%:1` ("root" pattern) optimization, it undered incorrectly, and should be replaced with [`anti ⌝`](https://uiua.org/docs/anti)[`pow ⁿ`](https://uiua.org/docs/power)
 - Add [`&seek`](https://uiua.org/docs/&seek) function for working with large files
 - Remove previously deprecated `signature` and `stringify` modifiers
-- Calling [`&tcpa`](https://uius.org/docs/&tcpa) on a TLS listener created with [`&tlsl`](https://uiua.org/docs/&tlsl) now automatically tries conducting a TSL handshake
+- Calling [`&tcpa`](https://uiua.org/docs/&tcpa) on a TLS listener created with [`&tlsl`](https://uiua.org/docs/&tlsl) now automatically tries conducting a TSL handshake
+- Add functions to work with UDP:
+  - [`&udpb`](https://uiua.org/docs/&udpb) to bind a socket
+  - [`&udpr`](https://uiua.org/docs/&udpr) to receive a datagram
+  - [`&udps`](https://uiua.org/docs/&udps) to send a datagram
+  - [`&udpsml`](https://uiua.org/docs/&udpsml) to set the maximum message length
 ### Interpreter
 - The fomatter no longer truncates trailing decimal `0`s from number literals
 - Implement filled adjacent [`stencil ⧈`](https://uiua.org/docs/stencil)

--- a/parser/src/defs.rs
+++ b/parser/src/defs.rs
@@ -3974,6 +3974,36 @@ sys_op! {
     (2(0), TcpSetWriteTimeout, Tcp, "&tcpswt", "tcp - set write timeout", Mutating),
     /// Get the connection address of a TCP socket
     (1, TcpAddr, Tcp, "&tcpaddr", "tcp - address", Mutating),
+    /// Bind a UDP socket
+    ///
+    /// Returns a UDP socket handle
+    /// You can receive messages with [&udpr] or send messages with [&udps].
+    /// You can adjust the maximum length of received messages using [&udpsml].
+    /// The default is 256 bytes.
+    ///
+    /// ex: S ← &udpb "0.0.0.0:7777"
+    ///   :
+    ///   : ⍢(&p $"_: _" °utf₈ &udpr S)1
+    /// This example binds a socket and then continuously prints received UTF₈ messages.
+    (1, UdpBind, Udp, "&udpb", "udp - bind", Mutating),
+    /// Receive a single message from a UDP socket
+    ///
+    /// Uses the internal maximum length, the default is 256 bytes.
+    /// To change the maximum length use [&udpsml]
+    /// Returns data and the address of the sender.
+    (1(2), UdpReceive, Udp, "&udpr", "udp - receive", Mutating),
+    /// Send a message on a UDP socket
+    ///
+    /// The first argument is the message to send in bytes.
+    /// The second argument is the address to send to.
+    /// The third argument is the UDP socket to send on.
+    (3(0), UdpSend, Udp, "&udps", "udp - send", Mutating),
+    /// Set the maximum message length for incoming messages
+    ///
+    /// Warning: Messages that contain more bytes than the max length will be chopped off.
+    ///
+    /// The default is 256 bytes.
+    (2(0), UdpSetMaxMsgLength, Udp, "&udpsml", "udp - set maximum message length", Mutating),
     /// Capture an image from a webcam
     ///
     /// Takes the index of the webcam to capture from.

--- a/parser/src/defs.rs
+++ b/parser/src/defs.rs
@@ -3983,7 +3983,7 @@ sys_op! {
     ///
     /// ex: S ← &udpb "0.0.0.0:7777"
     ///   :
-    ///   : ⍢(&p $"_: _" °utf₈ &udpr S)1
+    ///   : ⍢(&p ˜$"_: _" °utf₈ &udpr S)1
     /// This example binds a socket and then continuously prints received UTF₈ messages.
     (1, UdpBind, Udp, "&udpb", "udp - bind", Mutating),
     /// Receive a single message from a UDP socket

--- a/parser/src/primitive.rs
+++ b/parser/src/primitive.rs
@@ -286,6 +286,7 @@ pub enum SysOpClass {
     Command,
     Media,
     Tcp,
+    Udp,
     Ffi,
     Misc,
 }

--- a/site/src/docs.rs
+++ b/site/src/docs.rs
@@ -579,6 +579,7 @@ impl Allowed {
                         SysOpClass::Command => ("System - Commands".into_view(), "Execute commands"),
                         SysOpClass::Media => ("System - Media".into_view(), "Present media"),
                         SysOpClass::Tcp => ("System - TCP".into_view(), "Work with TCP sockets"),
+                        SysOpClass::Udp => ("System - UDP".into_view(), "Work with UDP sockets"),
                         SysOpClass::Ffi => ("System - FFI".into_view(), "Foreign function interface"),
                         SysOpClass::Misc => ("System - Misc".into_view(), ""),
                     }

--- a/src/sys/native.rs
+++ b/src/sys/native.rs
@@ -246,6 +246,7 @@ impl GlobalNativeSys {
                 && !self.tcp_listeners.contains_key(&handle)
                 && !self.tcp_sockets.contains_key(&handle)
                 && !self.tls_sockets.contains_key(&handle)
+                && !self.udp_sockets.contains_key(&handle)
             {
                 return handle;
             }


### PR DESCRIPTION
I wanted to work with UDP sockets and looked into the implementation in Rust's standard library. The API provided is different to TCP streams / listeners, in that there is no persistent connection when using UDP sockets. As such, special functions are required to work with them.

I have added four functions:
- `&udpb` binds a socket to an address
- `&udpr` receives a datagram in bytes on a socket
- `&udps` sends a datagram to an address on a socket
- `&udpsml` changes the maximum message length of a socket

The message length is required for receiving messages. It is used to initialize the buffer to which the datagram is written.
I decided to keep this state internally, as the value is unlikely to be changed often. This way, users don't have to provide the length every time a message is received.

I have tested the functions by sending datagrams to myself using multiple terminal sessions. I have also tested a simple pooled ping pong server, which worked.