### PR TITLE
fix: udp examples incorrectly run as part of testing

### DIFF
--- a/site/src/primitive.rs
+++ b/site/src/primitive.rs
@@ -417,7 +417,8 @@ fn prim_docs() {
         for line in &doc.lines {
             if let PrimDocLine::Example(ex) = line {
                 if [
-                    "&sl", "&tcpc", "&tlsc", "&ast", "&clip", "&frab", "&fmd", "&b",
+                    "&sl", "&tcpc", "&tlsc", "&ast", "&clip", "&frab", "&fmd", "&b", "&udpb",
+                    "&udpr", "&udps", "&udpsml",
                 ]
                 .iter()
                 .any(|prim| ex.input().contains(prim))

--- a/src/run_prim.rs
+++ b/src/run_prim.rs
@@ -2055,7 +2055,8 @@ mod tests {
                 if let PrimDocLine::Example(ex) = line {
                     if [
                         "&sl", "&tcpc", "&tlsc", "&ast", "&clip", "&fo", "&fc", "&fde", "&ftr",
-                        "&fld", "&fif", "&fras", "&frab", "&fmd", "timezone", "&b",
+                        "&fld", "&fif", "&fras", "&frab", "&fmd", "timezone", "&b", "&udpb",
+                        "&udpr", "&udps", "&udpsml",
                     ]
                     .iter()
                     .any(|prim| ex.input.contains(prim))


### PR DESCRIPTION
Some tests were failing because the UDP example was executed.