### PR TITLE
nix: remove apple frameworks and extra libffi usage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,6 @@
             packages = with pkgs; [
               lld_18
               trunk
-              libffi
               ((toolchainFor pkgs).override {
                 extensions = [
                   "rust-src"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,9 +6,7 @@
   lib,
   pkg-config,
   libffi,
-  libiconv,
   alsa-lib,
-  darwin,
   rustPlatform,
   doCheck ? true,
 }:
@@ -37,20 +35,7 @@ let
       rustPlatform.bindgenHook
       makeBinaryWrapper
     ];
-    buildInputs =
-      [ libffi ]
-      ++ lib.optionals stdenv.isLinux [ alsa-lib ]
-      ++ lib.optionals stdenv.isDarwin (
-        with darwin.apple_sdk.frameworks;
-        [
-          libiconv
-          AppKit
-          Foundation
-          CoreAudio
-          CoreMedia
-          AVFoundation
-        ]
-      );
+    buildInputs = [ libffi ] ++ lib.optionals stdenv.isLinux [ alsa-lib ];
     # https://crane.dev/faq/rebuilds-bindgen.html
     env.NIX_OUTPATH_USED_AS_RANDOM_SEED = "uiuarustbg";
   };


### PR DESCRIPTION
Removed `libffi` being explicitly listed in the `mkShell` because `inputsFrom = builtins.attrValues self'.packages;` already pulls in every dependency of the main build (which already uses `libffi`).

Removed the usage of `darwin.apple_sdk.frameworks` and `libiconv`. They are part of the `stdenv` on darwin by default, no need to list them explicitly anymore.

I did not bump the nixpkgs used revision.