### PR TITLE
fix(nix): fix wasm-bindgen version

### DIFF
--- a/nix/site.nix
+++ b/nix/site.nix
@@ -1,7 +1,7 @@
 {
   craneLib,
   lib,
-  wasm-bindgen-cli_0_2_100,
+  wasm-bindgen-cli_0_2_93,
   doCheck ? true,
 }:
 let
@@ -34,7 +34,7 @@ let
       cd ..
       mv ./docs/ ./dist
     '';
-    wasm-bindgen-cli = wasm-bindgen-cli_0_2_100;
+    wasm-bindgen-cli = wasm-bindgen-cli_0_2_93;
   };
 in
 craneLib.buildTrunkPackage totalArgs

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -18,7 +18,8 @@ serde_json = "1"
 uiua = {path = "..", default-features = false, features = ["batteries", "web"]}
 uiua-editor = {path = "../pad/editor"}
 urlencoding = "2"
-wasm-bindgen = "0.2.93"
+# NOTE: if you change the wasm-bindgen version, remember to change it in nix/site.nix as well
+wasm-bindgen = "=0.2.93"
 
 [dependencies.web-sys]
 features = [


### PR DESCRIPTION
A previous commit (#791) downgraded `wasm-bindgen`, which caused the site derivation to break. 