### PR TITLE
Allow prime in binding names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,8 @@ This version is not yet released. If you are reading this on the website, then t
 - Modules containing data definition variants now contains a `Variants` binding that lists their names
 - Add array pack syntactic sugar. This lets you write code like `[⊃(+|×)]` as `⊃[+|×]`.
 - Subscripts can now be typed with `,` instead of `__`s
+- Binding names can now end with prime characters `′`, `″`, and `‴`
+  - These will format from `'` at the end of a binding name
 - Add numeric subscripts for [`keep ▽`](https://uiua.org/docs/keep) to keep along a number of dimensions
 - Add [`under ⍜`](https://uiua.org/docs/under) capability to [`fork ⊃`](https://uiua.org/docs/fork)s of monadic functions
   - This allows using [`un °`](https://uiua.org/docs/un)[`by ⊸`](https://uiua.org/docs/by)[`fork ⊃`](https://uiua.org/docs/fork) to set multiple properties at once

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -558,7 +558,7 @@ impl Parser<'_> {
                     chars.extend(Primitive::non_deprecated().filter_map(|p| p.glyph()));
                     chars.extend(' '..='~');
                     chars.extend(SUBSCRIPT_DIGITS);
-                    chars.extend("←↚‼₋⌞⌟↓".chars());
+                    chars.extend("←↚‼′″‴₋⌞⌟↓".chars());
                     chars.sort_unstable();
                     chars
                 };
@@ -738,7 +738,12 @@ impl Parser<'_> {
             self.errors
                 .push(name.span.clone().sp(ParseError::AmpersandBindingName));
         }
-        if name.value.trim_end_matches(['!', '‼']).chars().count() >= 2
+        if name
+            .value
+            .trim_end_matches(['!', '‼', '\'', '′', '″', '‴'])
+            .chars()
+            .count()
+            >= 2
             && name.value.chars().next().unwrap().is_ascii_lowercase()
         {
             let captialized: String = name

--- a/src/run_prim.rs
+++ b/src/run_prim.rs
@@ -2479,7 +2479,7 @@ mod tests {
 	"repository": {{
         "idents": {{
             "name": "variable.parameter.uiua",
-            "match": "\\b[a-zA-Z]+(₋?[₀₁₂₃₄₅₆₇₈₉]|,`?\\d+)*[!‼]*\\b"
+            "match": "\\b[a-zA-Z]+['′″‴]*(₋?[₀₁₂₃₄₅₆₇₈₉]|,`?\\d+)*[!‼]*\\b"
         }},
 		"comments": {{
 			"name": "comment.line.uiua",


### PR DESCRIPTION
Currently, something like `F′₁` works, but `F₁′` does not.
