### PR TITLE
fix: cli args reset when an error occurs in repl

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -414,6 +414,7 @@ impl Uiua {
                 output_comments: take(&mut self.rt.output_comments),
                 reports: take(&mut self.rt.reports),
                 stack: take(&mut self.rt.stack),
+                cli_arguments: take(&mut self.rt.cli_arguments),
                 ..Runtime::default()
             };
         }


### PR DESCRIPTION
I was playing around with CLI arguments in the REPL and noticed that uncaught errors cause the arguments to reset.

To reproduce the issue:
1. create a dummy file `t.ua` (necessary because of how the REPL command is parsed by `clap`)
2. execute `uiua repl -- t.ua -f foo -b bar`
3. run some code that errors (like `⍤∩0`)
4. run `&args`
=> empty box array