### PR TITLE
Adding a nano config file to the list of editor extenstions for uiua.

### DIFF
--- a/site/src/other.rs
+++ b/site/src/other.rs
@@ -78,6 +78,7 @@ pub fn Install() -> impl IntoView {
         <p>"Language support in Neovim is easy with "<a href="https://github.com/neovim/nvim-lspconfig">"nvim-lspconfig"</a>"."</p>
         <p>"For Emacs, crmsnbleyd maintains a "<a href="https://github.com/crmsnbleyd/uiua-ts-mode">{lang}" mode"</a>"."</p>
         <p>"For Kakoune, ThaCuber maintains a "<a href="https://github.com/thacuber2a03/highlighters.kak/blob/main/uiua.kak">"syntax highlighting module"</a>"."</p>
+        <p>"For Nano, cqn-brwpna9 manatins a "<a href="https://github.com/cqn-brwpna9/uiua-nano-config">"nanorc for uiua"</a>"."</p>
         <p>"These require "{lang}" to be installed and in your "<code>"PATH"</code>"."</p>
 
         <Hd id="basic-usage">"Basic Usage"</Hd>


### PR DESCRIPTION
I wrote a [`uiua.nanorc`](https://github.com/cqn-brwpna9/uiua-nano-config) file and added it to the Install page.
This implementation doesn't use the language server protocol because that isn't possible in nano.