### PR TITLE
feat: Add some additional shadowable constants

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,9 @@ This version is not yet released. If you are reading this on the website, then t
 - Add experimental [`&fetch`](https://uiua.org/docs/&fetch) function to easily fetch data from a url
 - Add experimental monadic and triadic [`backward ˜`](https://uiua.org/docs/backward)
 - Add experimental sided subscripts for [`under ⍜`](https://uiua.org/docs/under), wich automatically [`dip ⊙`](https://uiua.org/docs/dip) on net-positive second functions
+- Add mathematical constants `φ` (golden ratio) and `γ` (Euler-Mascheroni)
+- Add `PlanetSymbols` and `ZodiacSymbols` constants, symbolic versions of `Planets` and `Zodiac`
+- Add `Elements` and `ElementSymbols` constants listing the chemical elements
 - Change experimental subscripted [`transpose ⍉`](https://uiua.org/docs/transpose) to transpose the first N axes
 - Deprecate [`duplicate .`](https://uiua.org/docs/duplicate)
 - Deprecate [`flip :`](https://uiua.org/docs/flip)
@@ -510,7 +513,7 @@ You can find the release announcement [here](https://uiua.org/blog/uiua-0.13.0).
 - `uiua repl` now has a `-s/--stack` flag to disable clearing the stack after each line
   - Clearing the stack is now the default
   - The `-c/--clear` has been removed
-- After programs finish executing, the terminal raw mode will be automatically disabled if it was left on. 
+- After programs finish executing, the terminal raw mode will be automatically disabled if it was left on.
 ### Website
 - Add [Ranges](https://uiua.org/tutorial/ranges) tutorial
 - Update the [Inverses](https://uiua.org/tutorial/inverses) tutorial with information about [`anti ⌝`](https://uiua.org/docs/anti) and [`obverse ⌅`](https://uiua.org/docs/obverse)
@@ -1222,8 +1225,8 @@ You can find the release announcement [here](https://uiua.org/blog/uiua-0.10.0).
 ### Language
 - Add the `reach ⟜` modifier, which removes the second value from the stack and calls its function.
 - Change how short spellings of [`dip ⊙`](https://uiua.org/docs/dip), [`gap ⋅`](https://uiua.org/docs/gap), and [`identity ∘`](https://uiua.org/docs/identity) work
-  - Instead of allowing them to be spelled with 2 characters, they can now be spelled with 1 character as long as there are at least 2 in the sequence. 
-  - If present, `'i'` may only come last. 
+  - Instead of allowing them to be spelled with 2 characters, they can now be spelled with 1 character as long as there are at least 2 in the sequence.
+  - If present, `'i'` may only come last.
   - `reach ⟜` is included.
 - Add 2-letter spellings of `deep ≊`, `abyss ≃`, and `seabed ∸` to make them consistent with `rock ⋄`.
 ### Interpreter
@@ -1451,7 +1454,7 @@ You may want to read the new version of the [Advanced Stack Manipulation Tutoria
 ## 2023-09-29
 ### Language
 - Make binding names case-sensitive
-- Add `^` syntax to terminate modifier parsing. 
+- Add `^` syntax to terminate modifier parsing.
 - Add [`&runi`](https://uiua.org/docs/&runi) and [`&runc`](https://uiua.org/docs/&runc) functions for running commands
 - Add [`&cd`](https://uiua.org/docs/&cd) function for changing the current working directory
 - Add shadowable [constants](https://uiua.org/docs/constants) like `e` and `os`

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -243,6 +243,10 @@ pub enum ConstClass {
 constant!(
     /// Euler's constant
     ("e", Math, std::f64::consts::E),
+    /// The golden ratio phi
+    ("φ", Math, 1.618_033_988_749_895_f64),
+    /// The Euler-Mascheroni constant
+    ("γ", Math, 0.577_215_664_901_532_9_f64),
     /// The real complex unit
     ("r", Math, crate::Complex::ONE),
     /// The imaginary unit
@@ -379,7 +383,13 @@ constant!(
         Fun,
         ["Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune"].as_slice()
     ),
-    /// The symbols of the zodiac
+    /// Symbols for each of the planets
+    (
+        "PlanetSymbols",
+        Fun,
+        ['☿', '♀', '🜨', '♂', '♃', '♄', '⛢', '♆']
+    ),
+    /// The signs of the zodiac
     (
         "Zodiac",
         Fun,
@@ -398,6 +408,12 @@ constant!(
             "Pisces"
         ]
         .as_slice()
+    ),
+    /// The symbols of the zodiac
+    (
+        "ZodiacSymbols",
+        Fun,
+        ['♈', '♉', '♊', '♋', '♌', '♍', '♎', '♏', '♐', '♑', '♒', '♓']
     ),
     /// The suits of a standard deck of playing cards
     ("Suits", Fun, ['♣', '♦', '♥', '♠']),
@@ -424,6 +440,36 @@ constant!(
     ("People", Fun, "👨👩👦👧"),
     /// Emoji hair components
     ("Hair", Fun, "🦰🦱🦲🦳"),
+    /// Names of each of the chemical elements
+    (
+        "Elements",
+        Fun,
+        [
+            "Hydrogen", "Helium", "Lithium", "Beryllium", "Boron", "Carbon", "Nitrogen", "Oxygen", "Fluorine", "Neon", "Sodium", "Magnesium", "Aluminium",
+            "Silicon", "Phosphorus", "Sulfur", "Chlorine", "Argon", "Potassium", "Calcium", "Scandium", "Titanium", "Vanadium", "Chromium", "Manganese",
+            "Iron", "Cobalt", "Nickel", "Copper", "Zinc", "Gallium", "Germanium", "Arsenic", "Selenium", "Bromine", "Krypton", "Rubidium", "Strontium",
+            "Yttrium", "Zirconium", "Niobium", "Molybdenum", "Technetium", "Ruthenium", "Rhodium", "Palladium", "Silver", "Cadmium", "Indium", "Tin",
+            "Antimony", "Tellurium", "Iodine", "Xenon", "Cesium", "Barium", "Lanthanum", "Cerium", "Praseodymium", "Neodymium", "Promethium", "Samarium",
+            "Europium", "Gadolinium", "Terbium", "Dysprosium", "Holmium", "Erbium", "Thulium", "Ytterbium", "Lutetium", "Hafnium", "Tantalum", "Tungsten",
+            "Rhenium", "Osmium", "Iridium", "Platinum", "Gold", "Mercury", "Thallium", "Lead", "Bismuth", "Polonium", "Astatine", "Radon", "Francium",
+            "Radium", "Actinium", "Thorium", "Protactinium", "Uranium", "Neptunium", "Plutonium", "Americium", "Curium", "Berkelium", "Californium",
+            "Einsteinium", "Fermium", "Mendelevium", "Nobelium", "Lawrencium", "Rutherfordium", "Dubnium", "Seaborgium", "Bohrium", "Hassium", "Meitnerium",
+            "Darmstadtium", "Roentgenium", "Copernicium", "Nihonium", "Flerovium", "Moscovium", "Livermorium", "Tennessine", "Oganesson"
+        ].as_slice()
+    ),
+    /// Symbols for each of the chemical elements
+    (
+        "ElementSymbols",
+        Fun,
+        [
+            "H", "He", "Li", "Be", "B", "C", "N", "O", "F", "Ne", "Na", "Mg", "Al", "Si", "P", "S", "Cl", "Ar", "K", "Ca", "Sc", "Ti", "V",
+            "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn", "Ga", "Ge", "As", "Se", "Br", "Kr", "Rb", "Sr", "Y", "Zr", "Nb", "Mo", "Tc", "Ru", "Rh",
+            "Pd", "Ag", "Cd", "In", "Sn", "Sb", "Te", "I", "Xe", "Cs", "Ba", "La", "Ce", "Pr", "Nd", "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho",
+            "Er", "Tm", "Yb", "Lu", "Hf", "Ta", "W", "Re", "Os", "Ir", "Pt", "Au", "Hg", "Tl", "Pb", "Bi", "Po", "At", "Rn", "Fr", "Ra", "Ac",
+            "Th", "Pa", "U", "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr", "Rf", "Db", "Sg", "Bh", "Hs", "Mt", "Ds", "Rg",
+            "Cn", "Nh", "Fl", "Mc", "Lv", "Ts", "Og"
+        ].as_slice()
+    ),
     /// The Uiua logo
     (#[cfg(feature = "image")] "Logo", Media, media::image_bytes_to_array(include_bytes!("assets/uiua-logo-512.png"), false, true).unwrap()),
     /// Ethically sourced Lena picture


### PR DESCRIPTION
This PR adds a few shadowable constants, perhaps of some use:

**Math:**
- `φ`, the golden ratio.
- `γ`, the Euler-Mascheroni constant.
(Both of these constants are in the process of being added as rust constants `std::f64::consts::PHI` and `std::f64::consts::EGAMMA`, but that's not stabilized yet (relevant feature flag is `more_float_constants`) so this PR just uses the raw definitions proposed there.)

**Fun:**
- `PlanetSymbols` and `ZodiacSymbols`, the astronomical symbols corresponding to existing constants `Planets` and `Zodiac`.
- `Elements` and `ElementSymbols`, the names and chemical symbols of the 118 chemical elements.