### PR TITLE
fix "a a" typo with strikethrough in random subtitle

### DIFF
--- a/site/src/main.rs
+++ b/site/src/main.rs
@@ -78,8 +78,8 @@ pub fn Site() -> impl IntoView {
         view!(<div style="font-style: normal"><Prim prim=Under glyph_only=true/>"🗄️🍴"</div>).into_view(),
         "It's got um...I um...arrays".into_view(),
         view!(<p style="font-size: 0.9em; max-width: 25em;">
-            "A monad is a "
-            <s>"monoid in the category of endofunctors"</s>
+            "A monad is "
+            <s>"a monoid in the category of endofunctors"</s>
             " a function with 1 argument"
         </p>)
         .into_view(),


### PR DESCRIPTION
currently it looks like this, which is wrong, since if you delete the strikethrough it says "a a"

<img width="604" height="364" alt="Screenshot 2025-12-02 at 8 31 19 PM" src="https://github.com/user-attachments/assets/7bb8a7c3-b1ab-488a-b320-668b2695ed3f" />
