### PR TITLE
Update links to Trunk project

### DIFF
--- a/site/readme.md
+++ b/site/readme.md
@@ -1,6 +1,6 @@
 # Uiua website
 
-This is a [Trunk](https://trunkrs.dev/)-powered single-page application.
+This is a [Trunk](https://trunk-rs.github.io/trunk/)-powered single-page application.
 To build it, try
 
 ```sh

--- a/site/src/other.rs
+++ b/site/src/other.rs
@@ -106,7 +106,7 @@ uiua watch -w"
         <Hd id="local-site">"Running the Site Locally"</Hd>
         <p>"This website is a static, single-page application. As such, it can be build and run locally, without connecting to a server."</p>
         <p>"To do this, you will need "<a href="https://www.rust-lang.org/tools/install">"Rust"</a>" installed. You will also need the "<a href="https://github.com/uiua-lang/uiua">{lang}" repository"</a>" cloned locally."</p>
-        <p>"You need to have both "<a href="https://trunkrs.dev">"Trunk"</a>" and the "<code>"wasm32-unknown-unknown"</code>" target installed. To get both of these, run:"</p>
+        <p>"You need to have both "<a href="https://trunk-rs.github.io/trunk/">"Trunk"</a>" and the "<code>"wasm32-unknown-unknown"</code>" target installed. To get both of these, run:"</p>
         <code class="code-block">"cargo install trunk\nrustup target add wasm32-unknown-unknown"</code>
         <p>"Then, from the root of the "{lang}" repository, run:"</p>
         <code class="code-block">"cd site\ntrunk serve"</code>


### PR DESCRIPTION
The Trunk project lost control of the `trunkrs.dev` domain, and it now features random ad content. This replaces Trunk links with a direct link to their GitHub-hosted site content.

See also https://github.com/trunk-rs/trunk/issues/1043