### PR TITLE
Use exp() for exponential

### DIFF
--- a/parser/src/complex.rs
+++ b/parser/src/complex.rs
@@ -1,6 +1,6 @@
 //! The [`Complex`] type
 
-use std::{f64::consts::E, fmt, ops::*};
+use std::{fmt, ops::*};
 
 use bytemuck::{Pod, Zeroable};
 use serde::*;
@@ -134,7 +134,7 @@ impl Complex {
     }
     /// Calculate the exponential of a complex number
     pub fn exp(self) -> Self {
-        Self::from_polar(E.powf(self.re), self.im)
+        Self::from_polar(1.0, self.im).safe_mul(Self::new(self.re.exp(), 0.0))
     }
     /// Calculate the natural logarithm of a complex number
     pub fn ln(self) -> Self {

--- a/src/algorithm/pervade.rs
+++ b/src/algorithm/pervade.rs
@@ -988,17 +988,15 @@ pub mod sqrt {
     }
 }
 pub mod exp {
-    use std::f64::consts::E;
-
     use super::*;
     pub fn num(a: f64) -> f64 {
-        E.powf(a)
+        a.exp()
     }
     pub fn byte(a: u8) -> f64 {
         num(a.into())
     }
     pub fn com(a: Complex) -> Complex {
-        Complex::new(E, 0.0).powc(a)
+        a.exp()
     }
     pub fn error<T: Display>(a: T, env: &Uiua) -> UiuaError {
         env.error(format!("Cannot take the exponential of {a}"))


### PR DESCRIPTION
This PR replaces the uses of generic pow for a more accurate and faster usage of exp, while preserving equality between complex and real inputs. That is, this will still return true:
```
/×=∩ₑ⊸(ℂ0)⇡ 1e6
```

Real performance:
```
⊙◌⍜now ₑ ⇡ 1e6
```
0.02626204490661621 -> 0.013309240341186523

Complex performance:
```
⊙◌⍜nowₑ˙⊞ℂ ⇡ 1e3
```
0.13152217864990234 -> 0.06182527542114258

I will note some inputs now return different values, but this is either because it's more accurate (`ₑ3` 20.085536923187664 -> 20.085536923187668) or gets rid of an incorrect NaN result (`ₑ∞r0i` ¯NaN+NaNi -> ∞ℂ)