### PR TITLE
Implement hdf5 reading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2838,6 +2838,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdf5-pure"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772af903b1f10f041af4ab6daa4959c1451f72146931653236571ee699e3aaee"
+dependencies = [
+ "byteorder",
+ "flate2",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6720,6 +6730,7 @@ dependencies = [
  "enum-iterator",
  "flate2",
  "gif 0.13.3",
+ "hdf5-pure",
  "highway",
  "hodaun",
  "hound",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,7 @@ web-sys = {version = "0.3.60", optional = true}
 eframe = {version = "0.33.0", optional = true, features = ["persistence"]}
 native-dialog = {version = "0.7.0", optional = true}
 rmp-serde = {version = "1.3.0", optional = true}
+hdf5-pure = "0.1.1"
 
 [features]
 apng = ["dep:png"]

--- a/parser/src/defs.rs
+++ b/parser/src/defs.rs
@@ -3238,6 +3238,10 @@ primitive!(
     ///
     /// See also: [derivative]
     ([1], Integral, Algorithm, ("integral", '∫'), { experimental: true }),
+    /// Decode HDF5 bytes into a nested map
+    ///
+    /// ex: hdf₅ &frab "data.hdf5"
+    (1, Hdf5, Encoding, "hdf"),
     /// Encode an array into a JSON string
     ///
     /// ex: json [1 2 3]

--- a/site/primitives.json
+++ b/site/primitives.json
@@ -917,6 +917,12 @@
     "class": "DyadicArray",
     "description": "Append two arrays end-to-end"
   },
+  "hdf": {
+    "args": 1,
+    "outputs": 1,
+    "class": "Encoding",
+    "description": "Decode HDF5 bytes into a nested map"
+  },
   "json": {
     "args": 1,
     "outputs": 1,

--- a/src/algorithm/encode.rs
+++ b/src/algorithm/encode.rs
@@ -10,6 +10,10 @@ use crate::{
     algorithm::validate_size, cowslice::CowSlice, fill::FillValue,
 };
 
+use hdf5_pure::types::{AttrValue, DType};
+use hdf5_pure::{File as Hdf5File, reader::Group};
+use std::collections::HashMap;
+
 use super::FillContext;
 
 impl Value {
@@ -962,5 +966,141 @@ impl Value {
             }
         }
         Ok(data.into())
+    }
+}
+
+impl Value {
+    fn hdf5_attrs_to_value(attrs: HashMap<String, AttrValue>, env: &Uiua) -> UiuaResult<Value> {
+        let mut keys: EcoVec<Boxed> = EcoVec::with_capacity(attrs.len());
+        let mut values: Vec<Value> = Vec::with_capacity(attrs.len());
+        for (k, v) in attrs {
+            keys.push(Boxed(k.into()));
+            let val: Value = match v {
+                AttrValue::F64(f) => f.into(),
+                AttrValue::F64Array(arr) => {
+                    Array::new([arr.len()], arr.into_iter().collect::<EcoVec<f64>>()).into()
+                }
+                AttrValue::I64(i) => (i as f64).into(),
+                AttrValue::I64Array(arr) => Array::new(
+                    [arr.len()],
+                    arr.into_iter().map(|x| x as f64).collect::<EcoVec<f64>>(),
+                )
+                .into(),
+                AttrValue::U64(u) => (u as f64).into(),
+                AttrValue::String(s) => s.into(),
+                AttrValue::StringArray(arr) => Array::from(
+                    arr.into_iter()
+                        .map(|s| Boxed(Value::from(s)))
+                        .collect::<EcoVec<_>>(),
+                )
+                .into(),
+                _ => return Err(env.error("hdf,5: unsupported attribute type")),
+            };
+            values.push(val);
+        }
+        let mut values = if values.iter().all(|v| v.shape.is_empty())
+            && values.windows(2).all(|w| w[0].type_id() == w[1].type_id())
+        {
+            Value::from_row_values_infallible(values)
+        } else {
+            Array::from(values.into_iter().map(Boxed).collect::<EcoVec<_>>()).into()
+        };
+        values.map(keys.into(), env)?;
+        Ok(values)
+    }
+
+    fn from_hdf5_group(group: &Group, env: &Uiua) -> UiuaResult<Value> {
+        let mut keys: EcoVec<Boxed> = EcoVec::new();
+        let mut values: Vec<Value> = Vec::new();
+
+        // subgroups -> recurse
+        for name in group
+            .groups()
+            .map_err(|e| env.error(format!("hdf,5: {e}")))?
+        {
+            keys.push(Boxed(name.clone().into()));
+            let subgroup = group
+                .group(&name)
+                .map_err(|e| env.error(format!("hdf,5: {e}")))?;
+            values.push(Self::from_hdf5_group(&subgroup, env)?);
+        }
+
+        // datasets -> typed arrays
+        for name in group
+            .datasets()
+            .map_err(|e| env.error(format!("hdf,5: {e}")))?
+        {
+            let ds = group
+                .dataset(&name)
+                .map_err(|e| env.error(format!("hdf,5: {e}")))?;
+            let raw_shape = ds.shape().map_err(|e| env.error(format!("hdf,5: {e}")))?;
+            let shape: Shape = raw_shape.iter().map(|&d| d as usize).collect();
+
+            let val: Value = match ds.dtype().map_err(|e| env.error(format!("hdf,5: {e}")))? {
+                DType::F32 | DType::F64 => {
+                    let data: EcoVec<f64> = ds
+                        .read_f64()
+                        .map_err(|e| env.error(format!("hdf,5: {e}")))?
+                        .into_iter()
+                        .collect();
+                    Array::new(shape, data).into()
+                }
+                DType::I8 | DType::I16 | DType::I32 | DType::I64 => {
+                    let data: EcoVec<f64> = ds
+                        .read_i64()
+                        .map_err(|e| env.error(format!("hdf,5: {e}")))?
+                        .into_iter()
+                        .map(|x| x as f64)
+                        .collect();
+                    Array::new(shape, data).into()
+                }
+                DType::U8 | DType::U16 | DType::U32 | DType::U64 => {
+                    let data: EcoVec<f64> = ds
+                        .read_u64()
+                        .map_err(|e| env.error(format!("hdf,5: {e}")))?
+                        .into_iter()
+                        .map(|x| x as f64)
+                        .collect();
+                    Array::new(shape, data).into()
+                }
+                DType::String | DType::VariableLengthString => {
+                    let strings: EcoVec<Boxed> = ds
+                        .read_string()
+                        .map_err(|e| env.error(format!("hdf,5: {e}")))?
+                        .into_iter()
+                        .map(|s| Boxed(Value::from(s)))
+                        .collect();
+                    Array::new(shape, strings).into()
+                }
+                _ => return Err(env.error(format!("hdf,5: unsupported dtype in \"{name}\""))),
+            };
+            keys.push(Boxed(name.into()));
+            values.push(val);
+        }
+
+        // attrs as "__attrs__" if non-empty
+        let attrs = group
+            .attrs()
+            .map_err(|e| env.error(format!("hdf,5: {e}")))?;
+        if !attrs.is_empty() {
+            keys.push(Boxed("__attrs__".into()));
+            values.push(Self::hdf5_attrs_to_value(attrs, env)?);
+        }
+
+        let mut values = if values.iter().all(|v| v.shape.is_empty())
+            && values.windows(2).all(|w| w[0].type_id() == w[1].type_id())
+        {
+            Value::from_row_values_infallible(values)
+        } else {
+            Array::from(values.into_iter().map(Boxed).collect::<EcoVec<_>>()).into()
+        };
+        values.map(keys.into(), env)?;
+        Ok(values)
+    }
+
+    pub(crate) fn from_hdf5_bytes(bytes: &[u8], env: &Uiua) -> UiuaResult<Self> {
+        let file = Hdf5File::from_bytes(bytes.to_vec()) // or whatever hdf5-pure accepts
+            .map_err(|e| env.error(format!("hdf,5: {e}")))?;
+        Self::from_hdf5_group(&file.root(), env)
     }
 }

--- a/src/run_prim.rs
+++ b/src/run_prim.rs
@@ -301,6 +301,12 @@ pub fn run_prim_func(prim: &Primitive, env: &mut Uiua) -> UiuaResult {
         }
         Primitive::Hsv => env.monadic_env(Value::rgb_to_hsv)?,
         Primitive::Oklch => env.monadic_env(Value::rgb_to_oklch)?,
+        Primitive::Hdf5 => {
+            let bytes = env.pop(1)?;
+            let bytes = bytes.as_bytes(env, "hdf,5 expects bytes")?;
+            let val = Value::from_hdf5_bytes(&bytes, env)?;
+            env.push(val);
+        }
         Primitive::Json => env.monadic_ref_env(Value::to_json_string)?,
         Primitive::Binary => env.monadic_ref_env(Value::to_binary)?,
         Primitive::Compress => {


### PR DESCRIPTION
my related proposal:
https://discord.com/channels/1156339038748413952/1496109415563001988

i tried my hand at implementing a hdf5 primitive that can read `hdf,5` files, in similar vein to `json`.

with this, `hdf` is a primitive that can take a byte array like `hdf &frab "data.h5"` and spit out a nested map representing the multi-dimensional tree-like structure of a hdf5-file (to my understanding. i am new to this file format)

i couldn't figure out how to have the default name of a primitive be a subscript, so the primitive is called `hdf`. 

currently `unhdf` is not implemented, but should be in the future to allow writing a nested map to bytes. i just needed file reading, so i only bothered with this for now.

since i'm kinda unfamiliar with rust, i used AI to do most of the implementation. for fun i am leaving the thread here:
https://kagi.com/assistant/e4e75dc0-8a17-4115-ad0e-7a5a7c5728bf

also my first PR, so hope this is up to snuff!