### PR TITLE
Fix multivector compile errors w/ --no-default-features

### DIFF
--- a/src/algorithm/monadic/multivector.rs
+++ b/src/algorithm/monadic/multivector.rs
@@ -32,6 +32,7 @@ impl Value {
         let n = new_shape.pop();
         let elem_count = new_shape.elements();
         Ok(match (n, mode.dims, mode.side) {
+            #[cfg(feature = "ga")]
             (Some(0), None, _) | (_, Some(0), _) => arr.convert::<Mv>().into(),
             (Some(0), Some(2), _) => {
                 Array::<Complex>::new(new_shape, eco_vec![Complex::ZERO; elem_count]).into()

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1278,7 +1278,14 @@ impl<'a> TypeEnv<'a> {
                     {
                         Scalar::Complex
                     } else {
-                        Scalar::Multivector
+                        #[cfg(feature = "ga")]
+                        {
+                            Scalar::Multivector
+                        }
+                        #[cfg(not(feature = "ga"))]
+                        {
+                            Scalar::Complex
+                        }
                     };
                     if let Some(suf) = &mut ty.shape.suffix {
                         suf.pop();

--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -33,6 +33,7 @@ pub enum Scalar {
     Int,
     Num,
     Complex,
+    #[cfg(feature = "ga")]
     Multivector,
     Ascii,
     Char,


### PR DESCRIPTION
I get a few errors pertaining to multivectors when compiling w/o default features. It seems that they're all resolvable by gating things behind  `#[cfg(feature = "ga")]`; I've done this and it seems to work and pass all the tests. 