### PR TITLE
Fix 64-bit atomics support for embedded targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6864,6 +6864,7 @@ dependencies = [
  "pastey 0.2.3",
  "pathdiff",
  "png 0.17.16",
+ "portable-atomic",
  "rand 0.10.2",
  "rapidhash",
  "rawrrr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ palette = {version = "0.7.6", default-features = false, features = ["std"]}
 parking_lot = "0.12.1"
 pastey = "0.2.3"
 pathdiff = "0.2.1"
+portable-atomic = "1"
 rand.workspace = true
 rapidhash = "4"
 rawrrr = {version = "0.2.1", optional = true}

--- a/src/algorithm/monadic/multivector.rs
+++ b/src/algorithm/monadic/multivector.rs
@@ -32,6 +32,7 @@ impl Value {
         let n = new_shape.pop();
         let elem_count = new_shape.elements();
         Ok(match (n, mode.dims, mode.side) {
+            #[cfg(feature = "ga")]
             (Some(0), None, _) | (_, Some(0), _) => arr.convert::<Mv>().into(),
             (Some(0), Some(2), _) => {
                 Array::<Complex>::new(new_shape, eco_vec![Complex::ZERO; elem_count]).into()

--- a/src/sys/native.rs
+++ b/src/sys/native.rs
@@ -10,10 +10,7 @@ use std::{
     path::{Path, PathBuf},
     process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, Stdio},
     slice,
-    sync::{
-        Arc, LazyLock,
-        atomic::{self, AtomicBool, AtomicU64},
-    },
+    sync::{Arc, LazyLock},
     thread::sleep,
     time::Duration,
 };
@@ -22,6 +19,7 @@ use colored::Colorize;
 #[cfg(feature = "webcam")]
 use crossbeam_channel as channel;
 use dashmap::DashMap;
+use portable_atomic::{self as atomic, AtomicBool, AtomicU64}; // add support for targets that don't support 64-bit atomics
 
 use crate::{
     BigConstant, GitTarget, Handle, MetaPtr, ReadLinesFn, ReadLinesReturnFn, Span, SysBackend,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1278,7 +1278,14 @@ impl<'a> TypeEnv<'a> {
                     {
                         Scalar::Complex
                     } else {
-                        Scalar::Multivector
+                        #[cfg(feature = "ga")]
+                        {
+                            Scalar::Multivector
+                        }
+                        #[cfg(not(feature = "ga"))]
+                        {
+                            Scalar::Complex
+                        }
                     };
                     if let Some(suf) = &mut ty.shape.suffix {
                         suf.pop();

--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -33,6 +33,7 @@ pub enum Scalar {
     Int,
     Num,
     Complex,
+    #[cfg(feature = "ga")]
     Multivector,
     Ascii,
     Char,


### PR DESCRIPTION
This adds portable-atomic to allow the interpeter to be run on architectures that don't natively support 64-bit atomic types. On normal architectures, portable-atomic is just a zero-cost passthrough, but it allows the interpreter to be run on nonstandard 32-bit processors like the esp32 I've been running it on. 

Depends on PR #993, since without it you can't compile at all with --no-default-features