### PR TITLE
Swap type-only validate behavior for scalar and box input

### DIFF
--- a/parser/src/defs.rs
+++ b/parser/src/defs.rs
@@ -2788,7 +2788,7 @@ primitive!(
     ///
     /// [validate] is more useful when used in conjunction with [type checking](https://www.uiua.org/docs/experimental#type-checking).
     ///
-    /// If the first argument is a scalar character, then a scalar array with the specified scalar type will be validated. You can use a scalar character in the form of a built-in constant. These constants all format from a name.
+    /// If the first argument is a scalar character, then an array with the specified scalar type will be validated. You can use a scalar character in the form of a built-in constant. These constants all format from a name.
     /// - `ℝ` - `num` - Real numbers
     /// - `ℤ` - `int` - Integers
     /// - `ℕ` - `nat` - Natural numbers
@@ -2796,7 +2796,7 @@ primitive!(
     /// - `𝕌` - `char` - Unicode characters
     /// ex: # Experimental!
     ///   : ⊨ℝ 5.1
-    /// ex! # Experimental!
+    /// ex: # Experimental!
     ///   : ⊨ℝ [1 2 3]
     /// ex! # Experimental!
     ///   : ⊨ℝ "hey"
@@ -2838,10 +2838,10 @@ primitive!(
     /// Shape and type can both be validated by using a box array where the type is the first item and the rest of the items are axis sizes.
     /// ex: # Experimental!
     ///   : ⊨{𝕌 ∞ 2} ["ab""cd"]
-    /// To allow for any shape, specify no axis sizes.
-    /// ex: # Experimental!
+    /// To require a scalar, specify no axis sizes.
+    /// ex! # Experimental!
     ///   : ⊨{ℤ} 5
-    ///   : ⊨{ℤ} [3 ¯6 2]
+    ///   : ⊨{𝕌} @a
     ///   : ⊨{ℤ} [1_2 3_4]
     /// Type specifications can be nested to specify box arrays with given types inside the boxes.
     /// ex: # Experimental!

--- a/src/types/ty.rs
+++ b/src/types/ty.rs
@@ -45,8 +45,7 @@ impl Type {
                 .map(|Boxed(val)| value_as_dim(val))
                 .collect::<Option<Vec<_>>>()
             {
-                let suffix = dims.is_empty().then(Vec::new);
-                scalar.shaped(DynShape { suffix, dims })
+                scalar.shaped(DynShape { suffix: None, dims })
             } else {
                 let shape = DynShape::from(arr.row_count());
                 let fields = (arr.data.iter())
@@ -74,7 +73,7 @@ impl Type {
                     _ => {}
                 }
             }
-            DynShape::SCALAR.with_scalar(value_as_scalar_spec(val)?)
+            DynShape::ANY.with_scalar(value_as_scalar_spec(val)?)
         };
         Some(ty)
     }

--- a/src/types/ty.rs
+++ b/src/types/ty.rs
@@ -45,7 +45,7 @@ impl Type {
                 .map(|Boxed(val)| value_as_dim(val))
                 .collect::<Option<Vec<_>>>()
             {
-                scalar.shaped(DynShape::from(dims))
+                scalar.shaped(dims)
             } else {
                 let shape = DynShape::from(arr.row_count());
                 let fields = (arr.data.iter())

--- a/src/types/ty.rs
+++ b/src/types/ty.rs
@@ -45,7 +45,7 @@ impl Type {
                 .map(|Boxed(val)| value_as_dim(val))
                 .collect::<Option<Vec<_>>>()
             {
-                scalar.shaped(DynShape { suffix: None, dims })
+                scalar.shaped(DynShape::from(dims))
             } else {
                 let shape = DynShape::from(arr.row_count());
                 let fields = (arr.data.iter())


### PR DESCRIPTION
I find the current behavior, where `⊨ℝ` validates both shape and type, unintuitive. A shape provided outside of a box validates only shape, not type; and the system uses box arrays as the method for provision of both type and shape information. 

This change makes non-boxed type information validate only type, and moves the `[0]`-shape validation to `⊨{ℝ}`. Intuitively, this is providing type and shape info, with the shape info empty.