### PR TITLE
Publically re-export `types::Type` struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,7 @@ pub use self::{
     shape::*,
     sys::*,
     tree::*,
+    types::Type,
     value::*,
 };
 #[doc(inline)]

--- a/src/types/ty.rs
+++ b/src/types/ty.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize)]
+#[doc(hidden)]
 pub struct Type {
     pub scalar: Scalar,
     pub shape: DynShape,


### PR DESCRIPTION
Need this for getting type information from .t fields